### PR TITLE
Add optional direct price to jobs (#23)

### DIFF
--- a/server/app/Filament/Resources/JobResource.php
+++ b/server/app/Filament/Resources/JobResource.php
@@ -52,7 +52,17 @@ class JobResource extends Resource
                             Forms\Components\Select::make('estimate_id')
                                 ->relationship('estimate', 'estimate_number')
                                 ->searchable()
-                                ->preload(),
+                                ->preload()
+                                ->live(),
+                            // Optional direct price — only when no estimate is attached (issue #23).
+                            Forms\Components\TextInput::make('price')
+                                ->label('Price')
+                                ->numeric()
+                                ->minValue(0)
+                                ->prefix('$')
+                                ->placeholder('0.00')
+                                ->helperText('Optional. Set a direct price for this job when no estimate is assigned.')
+                                ->visible(fn (Get $get): bool => blank($get('estimate_id'))),
                             Forms\Components\Select::make('crew_id')
                                 ->relationship('crew', 'name')
                                 ->searchable()
@@ -219,6 +229,11 @@ class JobResource extends Resource
                     ->formatStateUsing(fn (?string $state) => $state === 'recurring' ? 'Recurring' : 'One Time')
                     ->color(fn (?string $state) => $state === 'recurring' ? 'info' : 'gray')
                     ->toggleable(),
+                Tables\Columns\TextColumn::make('price')
+                    ->money('USD')
+                    ->placeholder('—')
+                    ->toggleable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('status')
                     ->badge(),
                 Tables\Columns\TextColumn::make('priority')

--- a/server/app/Models/Job.php
+++ b/server/app/Models/Job.php
@@ -30,6 +30,7 @@ class Job extends Model
         'customer_id',
         'property_id',
         'estimate_id',
+        'price',
         'recurring_job_template_id',
         'crew_id',
         'title',
@@ -58,6 +59,7 @@ class Job extends Model
             'started_at' => 'datetime',
             'finished_at' => 'datetime',
             'waiting_list' => 'boolean',
+            'price' => 'decimal:2',
         ];
     }
 

--- a/server/database/migrations/2026_06_18_000001_add_price_to_service_jobs_table.php
+++ b/server/database/migrations/2026_06_18_000001_add_price_to_service_jobs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_jobs', function (Blueprint $table) {
+            // Optional direct price for jobs that have no estimate attached (issue #23).
+            $table->decimal('price', 10, 2)->nullable()->after('estimate_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_jobs', function (Blueprint $table) {
+            $table->dropColumn('price');
+        });
+    }
+};


### PR DESCRIPTION
## Issue #23 — Jobs > New Job (optional price)

Adds an **optional** price field to jobs so a price can be given directly to a customer when no estimate is assigned.

### Changes
- **Migration** `add_price_to_service_jobs_table` — nullable `price` decimal(10,2) on `service_jobs`.
- **Job model** — `price` added to `$fillable` and cast `decimal:2`.
- **JobResource form** — reactive `Price` field ($ prefix, numeric, optional) shown only when no estimate is selected; the estimate select is now `->live()`.
- **JobResource table** — toggleable, sortable money column for `price`.

### Notes
- Persists for one-time jobs via the existing `Job::create($data)` path (the field is not stripped by the custom `handleRecordCreation`).
- Verified: migration runs, files lint clean, and a job round-trips the price (`149.50`) through the decimal cast.
- The same field will be reused by the quick-add "New Job" modal coming in #22.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)