### PR TITLE
Data-driven job statuses + Settings management tab (#25)

### DIFF
--- a/server/app/Filament/Pages/Settings.php
+++ b/server/app/Filament/Pages/Settings.php
@@ -45,6 +45,11 @@ class Settings extends Page
                         ->schema([
                             View::make('livewire.permission-manager-embed'),
                         ]),
+                    Tab::make('Job Status')
+                        ->icon('heroicon-o-flag')
+                        ->schema([
+                            View::make('livewire.job-status-manager-embed'),
+                        ]),
                 ]),
         ]);
     }

--- a/server/app/Filament/Resources/JobResource.php
+++ b/server/app/Filament/Resources/JobResource.php
@@ -58,14 +58,8 @@ class JobResource extends Resource
                                 ->searchable()
                                 ->preload(),
                             Forms\Components\Select::make('status')
-                                ->options([
-                                    'pending' => 'Pending',
-                                    'scheduled' => 'Scheduled',
-                                    'in_progress' => 'In Progress',
-                                    'completed' => 'Completed',
-                                    'skipped' => 'Skipped',
-                                    'cancelled' => 'Cancelled',
-                                ])
+                                ->options(fn (): array => \App\Models\JobStatus::options())
+                                ->default('pending')
                                 ->required(),
                             Forms\Components\Select::make('priority')
                                 ->options([
@@ -220,7 +214,9 @@ class JobResource extends Resource
                     ->color(fn (?string $state) => $state === 'recurring' ? 'info' : 'gray')
                     ->toggleable(),
                 Tables\Columns\TextColumn::make('status')
-                    ->badge(),
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state): ?string => \App\Models\JobStatus::options()[$state] ?? $state)
+                    ->color(fn (?string $state): string => \App\Models\JobStatus::colorMap()[$state] ?? 'gray'),
                 Tables\Columns\TextColumn::make('priority')
                     ->badge()
                     ->color(fn (?string $state) => match ($state) {
@@ -237,14 +233,7 @@ class JobResource extends Resource
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
                     ->label('Status')
-                    ->options([
-                        'pending' => 'Pending',
-                        'scheduled' => 'Scheduled',
-                        'in_progress' => 'In Progress',
-                        'completed' => 'Completed',
-                        'skipped' => 'Skipped',
-                        'cancelled' => 'Cancelled',
-                    ]),
+                    ->options(fn (): array => \App\Models\JobStatus::options()),
                 Tables\Filters\SelectFilter::make('priority')
                     ->label('Priority')
                     ->options([

--- a/server/app/Livewire/JobStatusManager.php
+++ b/server/app/Livewire/JobStatusManager.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Job;
+use App\Models\JobStatus;
+use Illuminate\Support\Str;
+use Livewire\Component;
+
+class JobStatusManager extends Component
+{
+    public array $statuses = [];
+
+    // Create/edit form
+    public bool $showForm = false;
+    public ?int $editingId = null;
+    public string $formLabel = '';
+    public string $formColor = 'gray';
+
+    public function mount(): void
+    {
+        $this->loadStatuses();
+    }
+
+    private function loadStatuses(): void
+    {
+        $statuses = JobStatus::orderBy('sort_order')->orderBy('label')->get();
+
+        // Count jobs per status so the UI can block deleting one that's in use.
+        $counts = Job::query()
+            ->selectRaw('status, count(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $this->statuses = $statuses->map(fn (JobStatus $s) => array_merge($s->toArray(), [
+            'jobs_count' => (int) ($counts[$s->name] ?? 0),
+        ]))->all();
+    }
+
+    public function openCreate(): void
+    {
+        $this->editingId = null;
+        $this->formLabel = '';
+        $this->formColor = 'gray';
+        $this->showForm = true;
+    }
+
+    public function openEdit(int $id): void
+    {
+        $status = JobStatus::find($id);
+        if (! $status) return;
+
+        $this->editingId = $status->id;
+        $this->formLabel = $status->label;
+        $this->formColor = $status->color;
+        $this->showForm = true;
+    }
+
+    public function closeForm(): void
+    {
+        $this->showForm = false;
+    }
+
+    public function saveStatus(): void
+    {
+        $label = trim($this->formLabel);
+        if ($label === '') return;
+
+        $color = array_key_exists($this->formColor, JobStatus::COLORS) ? $this->formColor : 'gray';
+
+        if ($this->editingId) {
+            $status = JobStatus::find($this->editingId);
+            if (! $status) return;
+
+            // Protected statuses keep their machine name (logic depends on it);
+            // only the label/color are editable.
+            $data = ['label' => $label, 'color' => $color];
+            if (! $status->is_protected) {
+                $data['name'] = $this->uniqueName($label, $status->id);
+            }
+            $status->update($data);
+        } else {
+            JobStatus::create([
+                'name' => $this->uniqueName($label),
+                'label' => $label,
+                'color' => $color,
+                'sort_order' => (int) (JobStatus::max('sort_order') ?? 0) + 1,
+                'is_protected' => false,
+            ]);
+        }
+
+        $this->showForm = false;
+        $this->loadStatuses();
+    }
+
+    public function deleteStatus(int $id): void
+    {
+        $status = JobStatus::find($id);
+        if (! $status) return;
+
+        if ($status->is_protected) {
+            session()->flash('job-status-error', 'Core statuses cannot be deleted.');
+            return;
+        }
+
+        if (Job::where('status', $status->name)->exists()) {
+            session()->flash('job-status-error', 'Cannot delete a status that is assigned to jobs.');
+            return;
+        }
+
+        $status->delete();
+        $this->loadStatuses();
+    }
+
+    private function uniqueName(string $label, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($label, '_') ?: 'status';
+        $name = $base;
+        $i = 2;
+        while (JobStatus::where('name', $name)->when($ignoreId, fn ($q) => $q->where('id', '!=', $ignoreId))->exists()) {
+            $name = $base . '_' . $i++;
+        }
+
+        return $name;
+    }
+
+    public function render()
+    {
+        return view('livewire.job-status-manager');
+    }
+}

--- a/server/app/Models/JobStatus.php
+++ b/server/app/Models/JobStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class JobStatus extends Model
+{
+    protected $table = 'job_statuses';
+
+    protected $fillable = [
+        'name',
+        'label',
+        'color',
+        'sort_order',
+        'is_protected',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_protected' => 'boolean',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    /** Filament badge colors available for a status. */
+    public const COLORS = [
+        'gray' => 'Gray',
+        'primary' => 'Blue',
+        'info' => 'Sky',
+        'success' => 'Green',
+        'warning' => 'Amber',
+        'danger' => 'Red',
+    ];
+
+    /**
+     * Ordered [name => label] map for select inputs / filters.
+     *
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        return static::orderBy('sort_order')->orderBy('label')->pluck('label', 'name')->all();
+    }
+
+    /**
+     * Ordered [name => color] map for badge coloring.
+     *
+     * @return array<string, string>
+     */
+    public static function colorMap(): array
+    {
+        return static::pluck('color', 'name')->all();
+    }
+}

--- a/server/database/migrations/2026_06_18_000002_create_job_statuses_table.php
+++ b/server/database/migrations/2026_06_18_000002_create_job_statuses_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('job_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();      // machine slug stored on service_jobs.status
+            $table->string('label');               // human label shown in the UI
+            $table->string('color')->default('gray'); // Filament badge color
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->boolean('is_protected')->default(false); // core statuses can't be deleted
+            $table->timestamps();
+        });
+
+        // Seed the core statuses (issue #25). These are protected from deletion
+        // because application logic and the mobile app rely on them.
+        $defaults = [
+            ['name' => 'pending',     'label' => 'Pending',      'color' => 'gray',    'sort_order' => 1],
+            ['name' => 'waiting_list', 'label' => 'Waiting List', 'color' => 'warning', 'sort_order' => 2],
+            ['name' => 'scheduled',   'label' => 'Scheduled',    'color' => 'info',    'sort_order' => 3],
+            ['name' => 'in_progress', 'label' => 'In Progress',  'color' => 'primary', 'sort_order' => 4],
+            ['name' => 'completed',   'label' => 'Completed',    'color' => 'success', 'sort_order' => 5],
+            ['name' => 'skipped',     'label' => 'Skipped',      'color' => 'warning', 'sort_order' => 6],
+            ['name' => 'cancelled',   'label' => 'Cancelled',    'color' => 'danger',  'sort_order' => 7],
+        ];
+
+        foreach ($defaults as $row) {
+            DB::table('job_statuses')->updateOrInsert(
+                ['name' => $row['name']],
+                array_merge($row, ['is_protected' => true, 'created_at' => now(), 'updated_at' => now()]),
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('job_statuses');
+    }
+};

--- a/server/resources/views/livewire/job-status-manager-embed.blade.php
+++ b/server/resources/views/livewire/job-status-manager-embed.blade.php
@@ -1,0 +1,1 @@
+@livewire('job-status-manager')

--- a/server/resources/views/livewire/job-status-manager.blade.php
+++ b/server/resources/views/livewire/job-status-manager.blade.php
@@ -1,0 +1,92 @@
+<div>
+    @php
+        $swatch = [
+            'gray' => '#6b7280', 'primary' => '#2563eb', 'info' => '#0ea5e9',
+            'success' => '#059669', 'warning' => '#d97706', 'danger' => '#dc2626',
+        ];
+    @endphp
+
+    @if(session('job-status-error'))
+        <div style="background: #fee2e2; color: #991b1b; padding: 10px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 14px;">
+            {{ session('job-status-error') }}
+        </div>
+    @endif
+
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+        <p style="font-size: 13px; color: #6b7280;">Manage the statuses a job can have. Core statuses can be renamed/recolored but not deleted.</p>
+        <button wire:click="openCreate" type="button" style="padding: 8px 16px; font-size: 13px; font-weight: 600; color: #fff; background: #c9092f; border: none; border-radius: 8px; cursor: pointer;">
+            + New Status
+        </button>
+    </div>
+
+    <div style="background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden;">
+        <table style="width: 100%; border-collapse: collapse; font-size: 14px;">
+            <thead>
+                <tr style="background: #f9fafb;">
+                    <th style="text-align: left; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Label</th>
+                    <th style="text-align: left; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Key</th>
+                    <th style="text-align: center; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Color</th>
+                    <th style="text-align: center; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Jobs</th>
+                    <th style="text-align: right; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($statuses as $status)
+                    <tr style="border-top: 1px solid #f3f4f6;">
+                        <td style="padding: 12px 16px;">
+                            <span style="display: inline-block; padding: 2px 10px; border-radius: 9999px; font-size: 12px; font-weight: 600; color: #fff; background: {{ $swatch[$status['color']] ?? '#6b7280' }};">{{ $status['label'] }}</span>
+                            @if($status['is_protected'])
+                                <span style="margin-left: 6px; font-size: 11px; color: #9ca3af;">core</span>
+                            @endif
+                        </td>
+                        <td style="padding: 12px 16px; color: #6b7280; font-family: monospace; font-size: 12px;">{{ $status['name'] }}</td>
+                        <td style="padding: 12px 16px; text-align: center;">
+                            <span style="display: inline-block; width: 14px; height: 14px; border-radius: 4px; background: {{ $swatch[$status['color']] ?? '#6b7280' }};"></span>
+                        </td>
+                        <td style="padding: 12px 16px; text-align: center; color: #6b7280;">{{ $status['jobs_count'] }}</td>
+                        <td style="padding: 12px 16px; text-align: right;">
+                            <button wire:click="openEdit({{ $status['id'] }})" type="button" style="padding: 4px 10px; font-size: 12px; border: 1px solid #d1d5db; border-radius: 6px; background: #fff; cursor: pointer; color: #374151; margin-right: 4px;">Edit</button>
+                            @if(! $status['is_protected'] && $status['jobs_count'] === 0)
+                                <button wire:click="deleteStatus({{ $status['id'] }})" wire:confirm="Delete this status?" type="button" style="padding: 4px 10px; font-size: 12px; border: 1px solid #fecaca; border-radius: 6px; background: #fff; cursor: pointer; color: #dc2626;">Delete</button>
+                            @endif
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="5" style="padding: 24px; text-align: center; color: #9ca3af;">No statuses defined.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    {{-- Create/Edit Modal --}}
+    @if($showForm)
+        <div wire:click.self="closeForm" style="position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.5);">
+            <div style="width: 100%; max-width: 400px; margin: 0 16px; background: #fff; border-radius: 16px; box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25); overflow: hidden;">
+                <div style="padding: 16px 20px; border-bottom: 1px solid #e5e7eb; display: flex; justify-content: space-between; align-items: center;">
+                    <h3 style="font-size: 16px; font-weight: 600; color: #111827;">{{ $editingId ? 'Edit Status' : 'New Status' }}</h3>
+                    <button wire:click="closeForm" type="button" style="color: #9ca3af; font-size: 20px; border: none; background: none; cursor: pointer;">&times;</button>
+                </div>
+                <div style="padding: 20px; display: flex; flex-direction: column; gap: 12px;">
+                    <div>
+                        <label style="display: block; font-size: 12px; font-weight: 600; color: #374151; margin-bottom: 4px;">Status Label *</label>
+                        <input wire:model="formLabel" type="text" placeholder="e.g. On Hold" style="width: 100%; padding: 9px 12px; font-size: 14px; border: 1px solid #d1d5db; border-radius: 8px; box-sizing: border-box;" />
+                    </div>
+                    <div>
+                        <label style="display: block; font-size: 12px; font-weight: 600; color: #374151; margin-bottom: 4px;">Color</label>
+                        <select wire:model="formColor" style="width: 100%; padding: 9px 12px; font-size: 14px; border: 1px solid #d1d5db; border-radius: 8px; box-sizing: border-box; background: #fff;">
+                            @foreach(\App\Models\JobStatus::COLORS as $value => $label)
+                                <option value="{{ $value }}">{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+                <div style="padding: 16px 20px; border-top: 1px solid #e5e7eb; display: flex; justify-content: flex-end; gap: 8px;">
+                    <button wire:click="closeForm" type="button" style="padding: 9px 18px; font-size: 14px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; cursor: pointer; color: #374151;">Cancel</button>
+                    <button wire:click="saveStatus" type="button" style="padding: 9px 18px; font-size: 14px; font-weight: 600; color: #fff; background: #c9092f; border: none; border-radius: 8px; cursor: pointer;">{{ $editingId ? 'Update' : 'Create' }}</button>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>


### PR DESCRIPTION
## Issue #25 — Jobs > Status

Makes the set of job statuses **Pending, Waiting List, Scheduled, In Progress, Completed, Skipped, Cancelled** the seeded baseline, and lets admins manage them (CRUD) from a new Settings tab.

### Changes
- **Migration** `create_job_statuses_table` — `name` (slug), `label`, `color`, `sort_order`, `is_protected`; seeds the 7 core statuses (idempotent `updateOrInsert`, all marked protected). Adds the previously-missing **Waiting List** status.
- **`JobStatus` model** — `options()` / `colorMap()` helpers and a `COLORS` palette (mapped to Filament badge colors).
- **`JobStatusManager` Livewire component** + blade + embed, mirroring the existing `RoleManager` pattern (modal create/edit, color picker, per-status job counts).
- **Settings page** — new **Job Status** tab.
- **JobResource** — status select options, table badge label+color, and status filter now read from `job_statuses` instead of hardcoded arrays.

### Safeguards
- Core (seeded) statuses can be renamed/recolored but **not deleted**, and keep their machine `name` so app/mobile logic stays valid.
- A status assigned to any job cannot be deleted.

### Verified
- Migration runs; all files lint clean.
- `JobStatus::options()` / `colorMap()` return the expected ordered maps.
- Component test: mount lists 7, create "On Hold" works, deleting a protected status is blocked, deleting an unused custom status works.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)