### PR TITLE
Managed service filters for the Waiting List (#26)

### DIFF
--- a/server/app/Filament/Pages/Scheduling.php
+++ b/server/app/Filament/Pages/Scheduling.php
@@ -42,6 +42,10 @@ class Scheduling extends Page
     #[Url(as: 'queue')]
     public string $queue = 'unassigned';
 
+    /** Optional service filter applied to the Waiting List queue (issue #26). */
+    #[Url(as: 'wlf')]
+    public ?int $waitingFilterId = null;
+
     public function mount(): void
     {
         $this->date ??= now()->toDateString();
@@ -53,6 +57,12 @@ class Scheduling extends Page
     public function setQueue(string $queue): void
     {
         $this->queue = $queue === 'waiting' ? 'waiting' : 'unassigned';
+    }
+
+    public function setWaitingFilter(?int $id): void
+    {
+        $this->waitingFilterId = $id ?: null;
+        unset($this->waitingListJobs);
     }
 
     public function getMaxContentWidth(): \Filament\Support\Enums\Width
@@ -313,6 +323,14 @@ class Scheduling extends Page
             ->pluck('job_id')
             ->all();
 
+        // Resolve the selected service-group filter (issue #26), if any.
+        $group = null;
+        if ($this->waitingFilterId) {
+            $group = \App\Models\WaitingListFilter::active()
+                ->whereKey($this->waitingFilterId)
+                ->value('service_group');
+        }
+
         return Job::query()
             ->with([
                 'customer:id,first_name,last_name,company_name',
@@ -321,11 +339,31 @@ class Scheduling extends Page
             ])
             ->where('waiting_list', true)
             ->whereNotIn('id', $anyRouteJobIds)
+            // Limit to jobs whose service (one-time line item or recurring template)
+            // belongs to the selected service group.
+            ->when($group, fn ($q) => $q->where(function ($qq) use ($group) {
+                $qq->whereHas('jobServices.service', fn ($s) => $s->where('service_group', $group))
+                   ->orWhereHas('recurringTemplate.service', fn ($s) => $s->where('service_group', $group));
+            }))
             ->orderByRaw('scheduled_date IS NULL') // dated jobs first
             ->orderBy('scheduled_date')
             ->orderBy('id')
             ->get()
             ->map(fn ($j) => $this->jobToArray($j))
+            ->all();
+    }
+
+    /**
+     * Active waiting-list service filters (issue #26), surfaced as chips above the
+     * Waiting List queue.
+     *
+     * @return array<int, array{id: int, label: string}>
+     */
+    #[Computed]
+    public function waitingListFilters(): array
+    {
+        return \App\Models\WaitingListFilter::ordered()
+            ->map(fn ($f) => ['id' => (int) $f->id, 'label' => $f->label])
             ->all();
     }
 

--- a/server/app/Filament/Pages/Settings.php
+++ b/server/app/Filament/Pages/Settings.php
@@ -45,6 +45,11 @@ class Settings extends Page
                         ->schema([
                             View::make('livewire.permission-manager-embed'),
                         ]),
+                    Tab::make('Waiting List')
+                        ->icon('heroicon-o-queue-list')
+                        ->schema([
+                            View::make('livewire.waiting-list-filter-manager-embed'),
+                        ]),
                 ]),
         ]);
     }

--- a/server/app/Livewire/WaitingListFilterManager.php
+++ b/server/app/Livewire/WaitingListFilterManager.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Service;
+use App\Models\WaitingListFilter;
+use Livewire\Component;
+
+class WaitingListFilterManager extends Component
+{
+    public array $filters = [];
+
+    // Create/edit form
+    public bool $showForm = false;
+    public ?int $editingId = null;
+    public string $formLabel = '';
+    public string $formServiceGroup = 'mowing';
+    public bool $formIsActive = true;
+
+    public function mount(): void
+    {
+        $this->loadFilters();
+    }
+
+    private function loadFilters(): void
+    {
+        $this->filters = WaitingListFilter::orderBy('sort_order')->orderBy('label')->get()->toArray();
+    }
+
+    public function groupOptions(): array
+    {
+        return Service::GROUPS;
+    }
+
+    public function openCreate(): void
+    {
+        $this->editingId = null;
+        $this->formLabel = '';
+        $this->formServiceGroup = array_key_first(Service::GROUPS) ?: 'mowing';
+        $this->formIsActive = true;
+        $this->showForm = true;
+    }
+
+    public function openEdit(int $id): void
+    {
+        $filter = WaitingListFilter::find($id);
+        if (! $filter) return;
+
+        $this->editingId = $filter->id;
+        $this->formLabel = $filter->label;
+        $this->formServiceGroup = $filter->service_group;
+        $this->formIsActive = $filter->is_active;
+        $this->showForm = true;
+    }
+
+    public function closeForm(): void
+    {
+        $this->showForm = false;
+    }
+
+    public function saveFilter(): void
+    {
+        $label = trim($this->formLabel);
+        if ($label === '') return;
+
+        $group = array_key_exists($this->formServiceGroup, Service::GROUPS)
+            ? $this->formServiceGroup
+            : array_key_first(Service::GROUPS);
+
+        $data = [
+            'label' => $label,
+            'service_group' => $group,
+            'is_active' => $this->formIsActive,
+        ];
+
+        if ($this->editingId) {
+            WaitingListFilter::where('id', $this->editingId)->update($data);
+        } else {
+            $data['sort_order'] = (int) (WaitingListFilter::max('sort_order') ?? 0) + 1;
+            WaitingListFilter::create($data);
+        }
+
+        $this->showForm = false;
+        $this->loadFilters();
+    }
+
+    public function deleteFilter(int $id): void
+    {
+        WaitingListFilter::whereKey($id)->delete();
+        $this->loadFilters();
+    }
+
+    public function render()
+    {
+        return view('livewire.waiting-list-filter-manager');
+    }
+}

--- a/server/app/Models/WaitingListFilter.php
+++ b/server/app/Models/WaitingListFilter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class WaitingListFilter extends Model
+{
+    protected $table = 'waiting_list_filters';
+
+    protected $fillable = [
+        'label',
+        'service_group',
+        'sort_order',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    /** Active filters in display order. */
+    public static function ordered(): \Illuminate\Support\Collection
+    {
+        return static::active()->orderBy('sort_order')->orderBy('label')->get();
+    }
+}

--- a/server/database/migrations/2026_06_18_000003_create_waiting_list_filters_table.php
+++ b/server/database/migrations/2026_06_18_000003_create_waiting_list_filters_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('waiting_list_filters', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');                 // shown as a chip on the waiting list
+            $table->string('service_group');         // matches Service::GROUPS key
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        // Seed the two starter filters from issue #26.
+        $defaults = [
+            ['label' => 'Mulch',  'service_group' => 'mulching', 'sort_order' => 1],
+            ['label' => 'Mowing', 'service_group' => 'mowing',   'sort_order' => 2],
+        ];
+
+        foreach ($defaults as $row) {
+            DB::table('waiting_list_filters')->updateOrInsert(
+                ['label' => $row['label']],
+                array_merge($row, ['is_active' => true, 'created_at' => now(), 'updated_at' => now()]),
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('waiting_list_filters');
+    }
+};

--- a/server/resources/views/filament/pages/scheduling.blade.php
+++ b/server/resources/views/filament/pages/scheduling.blade.php
@@ -258,6 +258,23 @@
                                     Waiting List ({{ count($waiting) }})
                                 </button>
                             </div>
+                            @if ($queue === 'waiting')
+                                @php $wlFilters = $this->waitingListFilters; @endphp
+                                @if (count($wlFilters) > 0)
+                                    <div class="sch-wl-filters" style="display:flex; flex-wrap:wrap; gap:6px; margin-bottom:6px;">
+                                        <button type="button" wire:click="setWaitingFilter(null)" class="d-btn"
+                                            @if (! $this->waitingFilterId) style="{{ $tabActive }}" @endif>
+                                            All
+                                        </button>
+                                        @foreach ($wlFilters as $f)
+                                            <button type="button" wire:click="setWaitingFilter({{ $f['id'] }})" class="d-btn"
+                                                @if ((int) $this->waitingFilterId === $f['id']) style="{{ $tabActive }}" @endif>
+                                                {{ $f['label'] }}
+                                            </button>
+                                        @endforeach
+                                    </div>
+                                @endif
+                            @endif
                             <div class="sch-col-sub">
                                 @if ($queue === 'waiting')
                                     Future jobs held back from the near-term pile. Drag onto a route, or send back to Unassigned.

--- a/server/resources/views/livewire/waiting-list-filter-manager-embed.blade.php
+++ b/server/resources/views/livewire/waiting-list-filter-manager-embed.blade.php
@@ -1,0 +1,1 @@
+@livewire('waiting-list-filter-manager')

--- a/server/resources/views/livewire/waiting-list-filter-manager.blade.php
+++ b/server/resources/views/livewire/waiting-list-filter-manager.blade.php
@@ -1,0 +1,80 @@
+<div>
+    @php $groups = $this->groupOptions(); @endphp
+
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+        <p style="font-size: 13px; color: #6b7280;">Manage the service filters shown above the Scheduling &rarr; Waiting List queue.</p>
+        <button wire:click="openCreate" type="button" style="padding: 8px 16px; font-size: 13px; font-weight: 600; color: #fff; background: #c9092f; border: none; border-radius: 8px; cursor: pointer;">
+            + New Filter
+        </button>
+    </div>
+
+    <div style="background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden;">
+        <table style="width: 100%; border-collapse: collapse; font-size: 14px;">
+            <thead>
+                <tr style="background: #f9fafb;">
+                    <th style="text-align: left; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Label</th>
+                    <th style="text-align: left; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Service Group</th>
+                    <th style="text-align: center; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Active</th>
+                    <th style="text-align: right; padding: 12px 16px; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($filters as $filter)
+                    <tr style="border-top: 1px solid #f3f4f6;">
+                        <td style="padding: 12px 16px; font-weight: 500;">{{ $filter['label'] }}</td>
+                        <td style="padding: 12px 16px; color: #6b7280;">{{ $groups[$filter['service_group']] ?? $filter['service_group'] }}</td>
+                        <td style="padding: 12px 16px; text-align: center;">
+                            @if($filter['is_active'])
+                                <span style="color: #059669; font-weight: 600;">Yes</span>
+                            @else
+                                <span style="color: #9ca3af;">No</span>
+                            @endif
+                        </td>
+                        <td style="padding: 12px 16px; text-align: right;">
+                            <button wire:click="openEdit({{ $filter['id'] }})" type="button" style="padding: 4px 10px; font-size: 12px; border: 1px solid #d1d5db; border-radius: 6px; background: #fff; cursor: pointer; color: #374151; margin-right: 4px;">Edit</button>
+                            <button wire:click="deleteFilter({{ $filter['id'] }})" wire:confirm="Delete this filter?" type="button" style="padding: 4px 10px; font-size: 12px; border: 1px solid #fecaca; border-radius: 6px; background: #fff; cursor: pointer; color: #dc2626;">Delete</button>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4" style="padding: 24px; text-align: center; color: #9ca3af;">No waiting list filters defined.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    {{-- Create/Edit Modal --}}
+    @if($showForm)
+        <div wire:click.self="closeForm" style="position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.5);">
+            <div style="width: 100%; max-width: 400px; margin: 0 16px; background: #fff; border-radius: 16px; box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25); overflow: hidden;">
+                <div style="padding: 16px 20px; border-bottom: 1px solid #e5e7eb; display: flex; justify-content: space-between; align-items: center;">
+                    <h3 style="font-size: 16px; font-weight: 600; color: #111827;">{{ $editingId ? 'Edit Filter' : 'New Filter' }}</h3>
+                    <button wire:click="closeForm" type="button" style="color: #9ca3af; font-size: 20px; border: none; background: none; cursor: pointer;">&times;</button>
+                </div>
+                <div style="padding: 20px; display: flex; flex-direction: column; gap: 12px;">
+                    <div>
+                        <label style="display: block; font-size: 12px; font-weight: 600; color: #374151; margin-bottom: 4px;">Filter Label *</label>
+                        <input wire:model="formLabel" type="text" placeholder="e.g. Mulch" style="width: 100%; padding: 9px 12px; font-size: 14px; border: 1px solid #d1d5db; border-radius: 8px; box-sizing: border-box;" />
+                    </div>
+                    <div>
+                        <label style="display: block; font-size: 12px; font-weight: 600; color: #374151; margin-bottom: 4px;">Service Group *</label>
+                        <select wire:model="formServiceGroup" style="width: 100%; padding: 9px 12px; font-size: 14px; border: 1px solid #d1d5db; border-radius: 8px; box-sizing: border-box; background: #fff;">
+                            @foreach($groups as $value => $label)
+                                <option value="{{ $value }}">{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                        <input wire:model="formIsActive" type="checkbox" style="width: 18px; height: 18px; accent-color: #c9092f;" />
+                        <span style="font-size: 14px; color: #374151;">Active (shown on the waiting list)</span>
+                    </label>
+                </div>
+                <div style="padding: 16px 20px; border-top: 1px solid #e5e7eb; display: flex; justify-content: flex-end; gap: 8px;">
+                    <button wire:click="closeForm" type="button" style="padding: 9px 18px; font-size: 14px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; cursor: pointer; color: #374151;">Cancel</button>
+                    <button wire:click="saveFilter" type="button" style="padding: 9px 18px; font-size: 14px; font-weight: 600; color: #fff; background: #c9092f; border: none; border-radius: 8px; cursor: pointer;">{{ $editingId ? 'Update' : 'Create' }}</button>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>


### PR DESCRIPTION
## Issue #26 — Waiting List > Service Filters

Adds a service filter to the **Scheduling → Waiting List** queue, plus a Settings tab to manage the filter values.

### Changes
- **Migration** `create_waiting_list_filters_table` — `label`, `service_group`, `sort_order`, `is_active`; seeds **Mulch → mulching** and **Mowing → mowing**.
- **`WaitingListFilter` model** — `active()` scope + `ordered()` helper.
- **Scheduling page** — new `waitingFilterId` (URL-persisted), `waitingListFilters()` computed, and `setWaitingFilter()`. The waiting-list query now matches jobs whose service (one-time line item or recurring template service) is in the selected group.
- **Scheduling blade** — filter chips (All + each active filter) above the Waiting List, only shown on that queue.
- **`WaitingListFilterManager` Livewire component** + blade + embed, and a new **Waiting List** tab in Settings (CRUD: label, service group, active).

### Verified
- Migration runs; all files lint clean; seeds present.
- Nested `whereHas` query executes without error.
- Data smoke test: a waiting-list job with a *mulching* service shows under the **Mulch** filter (1) and not under **Mowing** (0).

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)