### PR TITLE
Add managed Options to services (#21)

### DIFF
--- a/server/app/Filament/Resources/ServiceResource.php
+++ b/server/app/Filament/Resources/ServiceResource.php
@@ -113,6 +113,12 @@ class ServiceResource extends Resource
                 Tables\Columns\TextColumn::make('category')
                     ->badge()
                     ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('options_count')
+                    ->label('Options')
+                    ->counts('options')
+                    ->badge()
+                    ->placeholder('0')
+                    ->toggleable(),
                 Tables\Columns\IconColumn::make('is_active')
                     ->boolean(),
                 Tables\Columns\IconColumn::make('track_chemicals')
@@ -142,7 +148,9 @@ class ServiceResource extends Resource
 
     public static function getRelations(): array
     {
-        return [];
+        return [
+            ServiceResource\RelationManagers\OptionsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/server/app/Filament/Resources/ServiceResource/RelationManagers/OptionsRelationManager.php
+++ b/server/app/Filament/Resources/ServiceResource/RelationManagers/OptionsRelationManager.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Resources\ServiceResource\RelationManagers;
+
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class OptionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'options';
+
+    protected static ?string $title = 'Options';
+
+    protected static string | \BackedEnum | null $icon = 'heroicon-o-adjustments-horizontal';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255)
+                ->placeholder('e.g. Hand Laid, Machine Blown'),
+            Forms\Components\TextInput::make('price_adjustment')
+                ->label('Price adjustment')
+                ->helperText('Added to (or subtracted from) the service rate when this option is chosen.')
+                ->numeric()
+                ->default(0)
+                ->prefix('$'),
+            Forms\Components\TextInput::make('sort_order')
+                ->numeric()
+                ->default(0),
+            Forms\Components\Toggle::make('is_active')
+                ->default(true),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('name')
+            ->defaultSort('sort_order')
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('price_adjustment')
+                    ->label('Price Adj.')
+                    ->money('usd')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('sort_order')
+                    ->label('Order')
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->filters([])
+            ->headerActions([
+                Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+                Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/server/app/Models/Service.php
+++ b/server/app/Models/Service.php
@@ -71,6 +71,18 @@ class Service extends Model
         return $this->hasMany(EstimateLineItem::class);
     }
 
+    /** Selectable variations of this service, e.g. "Hand Laid" vs "Machine Blown" (issue #21). */
+    public function options(): HasMany
+    {
+        return $this->hasMany(ServiceOption::class)->orderBy('sort_order')->orderBy('name');
+    }
+
+    /** Active options only, for selection UIs. */
+    public function activeOptions(): HasMany
+    {
+        return $this->options()->where('is_active', true);
+    }
+
     /**
      * Public URL for the optional service icon, or null when none is set.
      */

--- a/server/app/Models/ServiceOption.php
+++ b/server/app/Models/ServiceOption.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ServiceOption extends Model
+{
+    protected $table = 'service_options';
+
+    protected $fillable = [
+        'service_id',
+        'name',
+        'price_adjustment',
+        'sort_order',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'price_adjustment' => 'decimal:2',
+            'sort_order' => 'integer',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Service::class);
+    }
+}

--- a/server/database/migrations/2026_06_18_000004_create_service_options_table.php
+++ b/server/database/migrations/2026_06_18_000004_create_service_options_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('service_options', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('service_id')->constrained()->cascadeOnDelete();
+            $table->string('name');                          // e.g. "Hand Laid", "Machine Blown"
+            $table->decimal('price_adjustment', 10, 2)->default(0); // +/- applied to the service rate
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_options');
+    }
+};


### PR DESCRIPTION
## Issue #21 — Services > Options

Lets a service define selectable **options** (e.g. Mulch → *Hand Laid* vs *Machine Blown*) so the service list can stay lean instead of carrying near-duplicate records.

### Changes
- **Migration** `create_service_options_table` — `service_id` (cascade delete), `name`, `price_adjustment`, `sort_order`, `is_active`.
- **`ServiceOption` model** — `belongsTo(Service)`.
- **`Service` model** — `options()` / `activeOptions()` relations.
- **`OptionsRelationManager`** on the Service edit page — full CRUD (name, price adjustment, order, active).
- **ServiceResource table** — toggleable **Options** count badge.

### Notes
- `price_adjustment` is added to/subtracted from the base service rate when the option is chosen, so options can carry pricing.
- Consuming options on estimate/job/invoice line items is a natural follow-up; this PR delivers the definition + management layer the issue asks for.

### Verified
- Migration runs; all files lint clean.
- Relation test: created *Hand Laid* (+\$25) and *Machine Blown*, count reflected as 2, ordering correct, cascade cleanup works.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)