### PR TITLE
Invoice line-item builder tab (#30)

### DIFF
--- a/server/app/Filament/Resources/InvoiceResource.php
+++ b/server/app/Filament/Resources/InvoiceResource.php
@@ -117,6 +117,13 @@ class InvoiceResource extends Resource
                                 ->columns(4)
                                 ->visible(fn (?Invoice $record) => $record?->is_payment_plan),
                         ]),
+                    Tab::make('Line Items')
+                        ->icon('heroicon-o-list-bullet')
+                        ->badge(fn (?Invoice $record): ?string => $record?->lineItems()->count() ?: null)
+                        ->hidden(fn (?Invoice $record): bool => ! $record?->exists)
+                        ->schema([
+                            View::make('filament.resources.invoice.line-items-tab'),
+                        ]),
                     Tab::make('Credits')
                         ->icon('heroicon-o-receipt-percent')
                         ->badge(fn (?Invoice $record): ?string => $record?->credits()->count() ?: null)

--- a/server/app/Livewire/InvoiceLineItemsManager.php
+++ b/server/app/Livewire/InvoiceLineItemsManager.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Invoice;
+use App\Models\InvoiceLineItem;
+use App\Models\Service;
+use Livewire\Component;
+
+class InvoiceLineItemsManager extends Component
+{
+    public Invoice $invoice;
+
+    public string $serviceSearch = '';
+    public bool $showServiceDropdown = false;
+
+    /** Working copy: ['id', 'service_id', 'description', 'quantity', 'unit_price', 'total']. */
+    public array $lines = [];
+
+    public function mount(Invoice $invoice): void
+    {
+        $this->invoice = $invoice;
+        $this->loadLines();
+    }
+
+    private function loadLines(): void
+    {
+        $this->lines = $this->invoice->lineItems()
+            ->orderBy('sort_order')
+            ->get()
+            ->map(fn (InvoiceLineItem $line) => [
+                'id' => (int) $line->id,
+                'service_id' => $line->service_id ? (int) $line->service_id : null,
+                'description' => $line->description ?? '',
+                'quantity' => number_format((float) $line->quantity, 2, '.', ''),
+                'unit_price' => number_format((float) $line->unit_price, 2, '.', ''),
+                'total' => number_format((float) $line->total, 2, '.', ''),
+            ])
+            ->all();
+    }
+
+    public function getServiceResultsProperty()
+    {
+        if (strlen($this->serviceSearch) < 1) {
+            return collect();
+        }
+
+        return Service::where('is_active', true)
+            ->where(function ($q) {
+                $q->where('name', 'like', "%{$this->serviceSearch}%")
+                  ->orWhere('full_name', 'like', "%{$this->serviceSearch}%")
+                  ->orWhere('code', 'like', "%{$this->serviceSearch}%");
+            })
+            ->orderBy('name')
+            ->limit(8)
+            ->get(['id', 'name', 'default_price']);
+    }
+
+    public function updatedServiceSearch(): void
+    {
+        $this->showServiceDropdown = strlen($this->serviceSearch) >= 1;
+    }
+
+    public function addService(int $serviceId): void
+    {
+        $service = Service::find($serviceId);
+        if (! $service) {
+            return;
+        }
+
+        $price = (float) ($service->default_price ?? 0);
+        InvoiceLineItem::create([
+            'invoice_id' => $this->invoice->id,
+            'service_id' => $service->id,
+            'description' => $service->name,
+            'quantity' => 1,
+            'unit_price' => $price,
+            'total' => $price,
+            'sort_order' => $this->nextSortOrder(),
+        ]);
+
+        $this->serviceSearch = '';
+        $this->showServiceDropdown = false;
+        $this->loadLines();
+        $this->refreshInvoice();
+    }
+
+    public function addCustomLine(): void
+    {
+        InvoiceLineItem::create([
+            'invoice_id' => $this->invoice->id,
+            'service_id' => null,
+            'description' => '',
+            'quantity' => 1,
+            'unit_price' => 0,
+            'total' => 0,
+            'sort_order' => $this->nextSortOrder(),
+        ]);
+
+        $this->loadLines();
+    }
+
+    /**
+     * Persist edits to a row. Quantity/price changes recompute that row's total
+     * and the invoice subtotal/total.
+     */
+    public function updatedLines($value, $key): void
+    {
+        [$index, $field] = array_pad(explode('.', $key, 2), 2, null);
+        $row = $this->lines[(int) $index] ?? null;
+        if (! $row || empty($row['id'])) {
+            return;
+        }
+
+        $qty = (float) ($row['quantity'] ?? 0);
+        $price = (float) ($row['unit_price'] ?? 0);
+        $total = round($qty * $price, 2);
+        $this->lines[(int) $index]['total'] = number_format($total, 2, '.', '');
+
+        InvoiceLineItem::where('id', $row['id'])->update([
+            'description' => $row['description'] ?? '',
+            'quantity' => $qty,
+            'unit_price' => $price,
+            'total' => $total,
+        ]);
+
+        $this->refreshInvoice();
+    }
+
+    public function removeLine(int $index): void
+    {
+        $row = $this->lines[$index] ?? null;
+        if (! $row) {
+            return;
+        }
+
+        if (! empty($row['id'])) {
+            InvoiceLineItem::where('id', $row['id'])->delete();
+        }
+
+        unset($this->lines[$index]);
+        $this->lines = array_values($this->lines);
+        $this->refreshInvoice();
+    }
+
+    public function getSubtotalProperty(): string
+    {
+        $sum = 0;
+        foreach ($this->lines as $line) {
+            $sum += (float) ($line['total'] ?? 0);
+        }
+        return number_format($sum, 2, '.', '');
+    }
+
+    private function refreshInvoice(): void
+    {
+        $this->invoice->recalculateFromLineItems();
+        $this->invoice->refresh();
+    }
+
+    private function nextSortOrder(): int
+    {
+        return ((int) $this->invoice->lineItems()->max('sort_order')) + 1;
+    }
+
+    public function render()
+    {
+        return view('livewire.invoice-line-items-manager');
+    }
+}

--- a/server/app/Models/Invoice.php
+++ b/server/app/Models/Invoice.php
@@ -84,11 +84,26 @@ class Invoice extends Model
         return $this->hasMany(Payment::class);
     }
 
+    public function lineItems(): HasMany
+    {
+        return $this->hasMany(InvoiceLineItem::class)->orderBy('sort_order');
+    }
+
     public function recalculateTotal(): void
     {
         $this->credits_total = $this->credits()->sum('amount');
         $this->total = $this->subtotal + $this->tax - $this->credits_total;
         $this->save();
+    }
+
+    /**
+     * Drive the invoice subtotal from its line items, then recompute the total
+     * (factoring tax and credits) (issue #30).
+     */
+    public function recalculateFromLineItems(): void
+    {
+        $this->subtotal = $this->lineItems()->sum('total');
+        $this->recalculateTotal();
     }
 
     /** Total received against this invoice. */

--- a/server/app/Models/InvoiceLineItem.php
+++ b/server/app/Models/InvoiceLineItem.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InvoiceLineItem extends Model
+{
+    protected $table = 'invoice_line_items';
+
+    protected $fillable = [
+        'invoice_id',
+        'service_id',
+        'description',
+        'quantity',
+        'unit_price',
+        'total',
+        'sort_order',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quantity' => 'decimal:2',
+            'unit_price' => 'decimal:2',
+            'total' => 'decimal:2',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    public function invoice(): BelongsTo
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Service::class);
+    }
+}

--- a/server/database/migrations/2026_06_18_000006_create_invoice_line_items_table.php
+++ b/server/database/migrations/2026_06_18_000006_create_invoice_line_items_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Mirrors estimate_line_items so invoices can be built row-by-row (issue #30).
+        Schema::create('invoice_line_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('invoice_id')->constrained('invoices')->cascadeOnDelete();
+            $table->foreignId('service_id')->nullable()->constrained('services')->nullOnDelete();
+            $table->string('description');
+            $table->decimal('quantity', 10, 2)->default(1);
+            $table->decimal('unit_price', 10, 2)->default(0);
+            $table->decimal('total', 10, 2)->default(0);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invoice_line_items');
+    }
+};

--- a/server/resources/views/filament/resources/invoice/line-items-tab.blade.php
+++ b/server/resources/views/filament/resources/invoice/line-items-tab.blade.php
@@ -1,0 +1,1 @@
+@livewire('invoice-line-items-manager', ['invoice' => $record], key('invoice-line-items-' . $record->id))

--- a/server/resources/views/livewire/invoice-line-items-manager.blade.php
+++ b/server/resources/views/livewire/invoice-line-items-manager.blade.php
@@ -1,0 +1,106 @@
+<div>
+    <div style="background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px;">
+        <label style="display: block; font-size: 12px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px;">Line Items</label>
+
+        {{-- Header --}}
+        @if(count($lines) > 0)
+            <div style="display: grid; grid-template-columns: 1fr 70px 100px 100px 36px; gap: 8px; padding: 0 0 8px; border-bottom: 1px solid #e5e7eb; margin-bottom: 8px;">
+                <span style="font-size: 11px; font-weight: 600; color: #9ca3af; text-transform: uppercase;">Description</span>
+                <span style="font-size: 11px; font-weight: 600; color: #9ca3af; text-transform: uppercase; text-align: center;">Qty</span>
+                <span style="font-size: 11px; font-weight: 600; color: #9ca3af; text-transform: uppercase; text-align: right;">Unit Price</span>
+                <span style="font-size: 11px; font-weight: 600; color: #9ca3af; text-transform: uppercase; text-align: right;">Total</span>
+                <span></span>
+            </div>
+        @endif
+
+        {{-- Rows --}}
+        @foreach($lines as $i => $line)
+            <div wire:key="inv-line-{{ $line['id'] ?? $i }}" style="display: grid; grid-template-columns: 1fr 70px 100px 100px 36px; gap: 8px; align-items: center; padding: 6px 0; border-bottom: 1px solid #f3f4f6;">
+                <input
+                    wire:model.blur="lines.{{ $i }}.description"
+                    type="text"
+                    placeholder="Description"
+                    style="padding: 7px 10px; font-size: 14px; border: 1px solid #e5e7eb; border-radius: 6px; width: 100%; box-sizing: border-box;"
+                />
+                <input
+                    wire:model.blur="lines.{{ $i }}.quantity"
+                    type="number" min="0" step="0.01"
+                    style="padding: 7px 6px; font-size: 14px; border: 1px solid #e5e7eb; border-radius: 6px; text-align: center; width: 100%; box-sizing: border-box;"
+                />
+                <input
+                    wire:model.blur="lines.{{ $i }}.unit_price"
+                    type="number" min="0" step="0.01"
+                    style="padding: 7px 6px; font-size: 14px; border: 1px solid #e5e7eb; border-radius: 6px; text-align: right; width: 100%; box-sizing: border-box;"
+                />
+                <span style="font-size: 14px; color: #111827; text-align: right; font-weight: 500;">${{ number_format((float) $line['total'], 2) }}</span>
+                <button
+                    wire:click="removeLine({{ $i }})"
+                    type="button"
+                    style="color: #dc2626; border: none; background: none; cursor: pointer; font-size: 16px; padding: 4px;"
+                >&times;</button>
+            </div>
+        @endforeach
+
+        @if(count($lines) === 0)
+            <p style="font-size: 13px; color: #9ca3af; text-align: center; padding: 16px 0;">No line items yet. Search a service below or add a custom line.</p>
+        @endif
+
+        {{-- Add controls --}}
+        <div style="margin-top: 12px; display: flex; gap: 8px; align-items: flex-start;">
+            <div style="flex: 1; position: relative;">
+                <input
+                    wire:model.live.debounce.300ms="serviceSearch"
+                    wire:focus="$set('showServiceDropdown', true)"
+                    type="text"
+                    placeholder="Search services to add..."
+                    style="width: 100%; padding: 8px 12px; font-size: 13px; border: 1px solid #d1d5db; border-radius: 8px; outline: none; box-sizing: border-box;"
+                />
+                @if($showServiceDropdown && $this->serviceResults->count() > 0)
+                    <div style="position: absolute; z-index: 20; top: 100%; left: 0; right: 0; margin-top: 4px; background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; box-shadow: 0 10px 25px rgba(0,0,0,0.1); max-height: 200px; overflow-y: auto;">
+                        @foreach($this->serviceResults as $svc)
+                            <button
+                                wire:click="addService({{ $svc->id }})"
+                                type="button"
+                                style="width: 100%; text-align: left; padding: 10px 14px; border: none; background: none; cursor: pointer; font-size: 13px; border-bottom: 1px solid #f3f4f6; display: flex; justify-content: space-between;"
+                                onmouseover="this.style.background='#f9fafb'" onmouseout="this.style.background='none'"
+                            >
+                                <span style="font-weight: 500; color: #111827;">{{ $svc->name }}</span>
+                                @if($svc->default_price)
+                                    <span style="color: #6b7280;">${{ number_format($svc->default_price, 2) }}</span>
+                                @endif
+                            </button>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+            <button
+                wire:click="addCustomLine"
+                type="button"
+                style="padding: 8px 14px; font-size: 13px; font-weight: 600; color: #374151; background: #f9fafb; border: 1px solid #d1d5db; border-radius: 8px; cursor: pointer; white-space: nowrap;"
+            >+ Custom line</button>
+        </div>
+
+        {{-- Totals --}}
+        <div style="margin-top: 16px; padding-top: 12px; border-top: 1px solid #e5e7eb; max-width: 280px; margin-left: auto;">
+            <div style="display: flex; justify-content: space-between; margin-bottom: 6px;">
+                <span style="font-size: 13px; color: #6b7280;">Subtotal</span>
+                <span style="font-size: 14px; font-weight: 600; color: #111827;">${{ $this->subtotal }}</span>
+            </div>
+            <div style="display: flex; justify-content: space-between; margin-bottom: 6px;">
+                <span style="font-size: 13px; color: #6b7280;">Tax</span>
+                <span style="font-size: 13px; color: #6b7280;">${{ number_format((float) $invoice->tax, 2) }}</span>
+            </div>
+            @if((float) $invoice->credits_total > 0)
+                <div style="display: flex; justify-content: space-between; margin-bottom: 6px;">
+                    <span style="font-size: 13px; color: #6b7280;">Credits</span>
+                    <span style="font-size: 13px; color: #6b7280;">-${{ number_format((float) $invoice->credits_total, 2) }}</span>
+                </div>
+            @endif
+            <div style="display: flex; justify-content: space-between; padding-top: 8px; border-top: 1px solid #e5e7eb;">
+                <span style="font-size: 14px; font-weight: 700; color: #111827;">Total</span>
+                <span style="font-size: 16px; font-weight: 700; color: #111827;">${{ number_format((float) $invoice->total, 2) }}</span>
+            </div>
+            <p style="font-size: 11px; color: #9ca3af; margin-top: 8px;">Subtotal &amp; total update automatically from the line items above. Tax is set on the General tab.</p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Issue #30 — Invoices > Edit (line-item builder)

Adds a custom Livewire **Line Items** tab to invoices so they can be built row-by-row (service, qty, price) with totals updating live — like building an estimate. Scoped to *only* this gap; the existing General, Credits, and Payments tabs (and the payment form) are left as-is.

### Changes
- **Migration** `create_invoice_line_items_table` — mirrors `estimate_line_items` (`invoice_id`, `service_id`, `description`, `quantity`, `unit_price`, `total`, `sort_order`).
- **`InvoiceLineItem` model** + **`Invoice::lineItems()`** relation.
- **`Invoice::recalculateFromLineItems()`** — sets `subtotal` from the line totals, then recomputes `total` (tax − credits) via the existing `recalculateTotal()`.
- **`InvoiceLineItemsManager` Livewire** — service search/add, custom line, per-row qty × unit price, live subtotal/total; every edit persists immediately.
- **InvoiceResource** — new **Line Items** tab (badge = count), placed before Credits, hidden until the invoice exists (same convention as Credits/Payments).

### Verified
- Migration runs; all files lint clean.
- Round-trip: add a $50 service → subtotal $50 / total $60 (tax $10); set qty 3 → $150 / $160; remove → $0 / $10. Tax and credits factored correctly.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)