### PR TITLE
Customer Jobs / Estimates / Payments tabs (#22)

### DIFF
--- a/server/app/Filament/Resources/CustomerResource.php
+++ b/server/app/Filament/Resources/CustomerResource.php
@@ -92,12 +92,33 @@ class CustomerResource extends Resource
                         ->schema([
                             View::make('filament.resources.customer.properties-tab'),
                         ]),
+                    Tab::make('Jobs')
+                        ->icon('heroicon-o-clipboard-document-list')
+                        ->badge(fn (?Customer $record): ?string => $record?->jobs()->count() ?: null)
+                        ->hidden(fn (?Customer $record): bool => ! $record?->exists)
+                        ->schema([
+                            View::make('filament.resources.customer.jobs-tab'),
+                        ]),
+                    Tab::make('Estimates')
+                        ->icon('heroicon-o-calculator')
+                        ->badge(fn (?Customer $record): ?string => $record?->estimates()->count() ?: null)
+                        ->hidden(fn (?Customer $record): bool => ! $record?->exists)
+                        ->schema([
+                            View::make('filament.resources.customer.estimates-tab'),
+                        ]),
                     Tab::make('Invoices')
                         ->icon('heroicon-o-document-text')
                         ->badge(fn (?Customer $record): ?string => $record?->invoices()->count() ?: null)
                         ->hidden(fn (?Customer $record): bool => ! $record?->exists)
                         ->schema([
                             View::make('filament.resources.customer.invoices-tab'),
+                        ]),
+                    Tab::make('Payments')
+                        ->icon('heroicon-o-banknotes')
+                        ->badge(fn (?Customer $record): ?string => $record?->payments()->count() ?: null)
+                        ->hidden(fn (?Customer $record): bool => ! $record?->exists)
+                        ->schema([
+                            View::make('filament.resources.customer.payments-tab'),
                         ]),
                 ]),
         ]);

--- a/server/app/Filament/Resources/CustomerResource/RelationManagers/EstimatesRelationManager.php
+++ b/server/app/Filament/Resources/CustomerResource/RelationManagers/EstimatesRelationManager.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Filament\Resources\CustomerResource\RelationManagers;
+
+use Filament\Actions;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class EstimatesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'estimates';
+
+    protected static string | \BackedEnum | null $icon = 'heroicon-o-calculator';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('estimate_number')
+            ->defaultSort('id', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('estimate_number')
+                    ->label('Estimate #')
+                    ->searchable()
+                    ->sortable()
+                    // Link the ID straight to the estimate detail (edit) view.
+                    ->url(fn ($record) => route('filament.admin.resources.estimates.edit', $record))
+                    ->color('primary'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('total')
+                    ->money('usd')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('valid_until')
+                    ->label('Valid Until')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Created')
+                    ->date()
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'draft' => 'Draft',
+                        'sent' => 'Sent',
+                        'accepted' => 'Accepted',
+                        'declined' => 'Declined',
+                        'expired' => 'Expired',
+                    ]),
+            ])
+            ->actions([
+                Actions\Action::make('details')
+                    ->label('Details')
+                    ->icon('heroicon-o-pencil-square')
+                    ->url(fn ($record) => route('filament.admin.resources.estimates.edit', $record)),
+                // The same public page the client sees.
+                Actions\Action::make('view_public')
+                    ->label('View')
+                    ->icon('heroicon-o-eye')
+                    ->url(fn ($record) => $record->share_token ? $record->getPublicUrl() : null)
+                    ->openUrlInNewTab()
+                    ->visible(fn ($record) => (bool) $record->share_token),
+            ]);
+    }
+}

--- a/server/app/Filament/Resources/CustomerResource/RelationManagers/JobsRelationManager.php
+++ b/server/app/Filament/Resources/CustomerResource/RelationManagers/JobsRelationManager.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Filament\Resources\CustomerResource\RelationManagers;
+
+use App\Models\Property;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class JobsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'jobs';
+
+    protected static string | \BackedEnum | null $icon = 'heroicon-o-clipboard-document-list';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Forms\Components\Select::make('property_id')
+                ->label('Property')
+                ->options(fn (): array => Property::query()
+                    ->where('customer_id', $this->getOwnerRecord()->getKey())
+                    ->orderByDesc('is_primary')
+                    ->orderBy('address')
+                    ->pluck('address', 'id')
+                    ->all())
+                ->searchable()
+                ->required(),
+            Forms\Components\TextInput::make('title')
+                ->required()
+                ->maxLength(255)
+                ->placeholder('Mowing, Mulch install, Spring cleanup…'),
+            Forms\Components\Select::make('status')
+                ->options([
+                    'pending' => 'Pending',
+                    'scheduled' => 'Scheduled',
+                    'in_progress' => 'In Progress',
+                    'completed' => 'Completed',
+                    'skipped' => 'Skipped',
+                    'cancelled' => 'Cancelled',
+                ])
+                ->default('pending')
+                ->required(),
+            Forms\Components\Select::make('priority')
+                ->options([
+                    'low' => 'Low',
+                    'normal' => 'Normal',
+                    'high' => 'High',
+                    'urgent' => 'Urgent',
+                ])
+                ->default('normal')
+                ->required(),
+            Forms\Components\DatePicker::make('scheduled_date')
+                ->label('Scheduled date'),
+            Forms\Components\Textarea::make('notes')
+                ->columnSpanFull(),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('title')
+            ->defaultSort('id', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('Job #')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->limit(40),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('priority')
+                    ->badge()
+                    ->color(fn (?string $state) => match ($state) {
+                        'urgent', 'high' => 'danger',
+                        'normal' => 'warning',
+                        'low' => 'success',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('scheduled_date')
+                    ->date()
+                    ->placeholder('TBD')
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'pending' => 'Pending',
+                        'scheduled' => 'Scheduled',
+                        'in_progress' => 'In Progress',
+                        'completed' => 'Completed',
+                        'skipped' => 'Skipped',
+                        'cancelled' => 'Cancelled',
+                    ]),
+            ])
+            ->headerActions([
+                Actions\CreateAction::make()
+                    ->label('New Job')
+                    ->icon('heroicon-o-plus')
+                    ->mutateFormDataUsing(function (array $data): array {
+                        $data['type'] = $data['type'] ?? 'one_time';
+                        return $data;
+                    }),
+            ])
+            ->actions([
+                Actions\Action::make('open')
+                    ->label('Details')
+                    ->icon('heroicon-o-eye')
+                    ->url(fn ($record) => route('filament.admin.resources.jobs.edit', $record)),
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/server/app/Filament/Resources/CustomerResource/RelationManagers/PaymentsRelationManager.php
+++ b/server/app/Filament/Resources/CustomerResource/RelationManagers/PaymentsRelationManager.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Filament\Resources\CustomerResource\RelationManagers;
+
+use App\Models\Payment;
+use Filament\Actions;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PaymentsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'payments';
+
+    protected static string | \BackedEnum | null $icon = 'heroicon-o-banknotes';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('reference')
+            ->defaultSort('paid_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('paid_at')
+                    ->label('Date')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('invoice.invoice_number')
+                    ->label('Invoice #')
+                    ->searchable()
+                    ->url(fn (Payment $record) => $record->invoice
+                        ? route('filament.admin.resources.invoices.edit', $record->invoice)
+                        : null)
+                    ->color('primary'),
+                Tables\Columns\TextColumn::make('amount')
+                    ->money('usd')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('method')
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state) => Payment::METHODS[$state] ?? $state),
+                Tables\Columns\TextColumn::make('reference')
+                    ->label('Reference')
+                    ->searchable()
+                    ->placeholder('—'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('method')
+                    ->options(Payment::METHODS),
+                Tables\Filters\Filter::make('paid_at')
+                    ->schema([
+                        \Filament\Forms\Components\DatePicker::make('from')->label('Paid from'),
+                        \Filament\Forms\Components\DatePicker::make('until')->label('Paid until'),
+                    ])
+                    ->query(function ($query, array $data) {
+                        return $query
+                            ->when($data['from'] ?? null, fn ($q, $d) => $q->whereDate('paid_at', '>=', $d))
+                            ->when($data['until'] ?? null, fn ($q, $d) => $q->whereDate('paid_at', '<=', $d));
+                    }),
+            ])
+            ->actions([
+                Actions\Action::make('invoice')
+                    ->label('Invoice')
+                    ->icon('heroicon-o-document-text')
+                    ->url(fn (Payment $record) => $record->invoice
+                        ? route('filament.admin.resources.invoices.edit', $record->invoice)
+                        : null)
+                    ->visible(fn (Payment $record) => (bool) $record->invoice),
+            ]);
+    }
+}

--- a/server/app/Models/Customer.php
+++ b/server/app/Models/Customer.php
@@ -66,4 +66,9 @@ class Customer extends Model
     {
         return $this->hasMany(Invoice::class);
     }
+
+    public function payments(): HasMany
+    {
+        return $this->hasMany(Payment::class);
+    }
 }

--- a/server/resources/views/filament/resources/customer/estimates-tab.blade.php
+++ b/server/resources/views/filament/resources/customer/estimates-tab.blade.php
@@ -1,0 +1,5 @@
+@livewire(
+    App\Filament\Resources\CustomerResource\RelationManagers\EstimatesRelationManager::class,
+    ['ownerRecord' => $record, 'pageClass' => $this::class],
+    key('estimates-' . $record->getKey()),
+)

--- a/server/resources/views/filament/resources/customer/jobs-tab.blade.php
+++ b/server/resources/views/filament/resources/customer/jobs-tab.blade.php
@@ -1,0 +1,5 @@
+@livewire(
+    App\Filament\Resources\CustomerResource\RelationManagers\JobsRelationManager::class,
+    ['ownerRecord' => $record, 'pageClass' => $this::class],
+    key('jobs-' . $record->getKey()),
+)

--- a/server/resources/views/filament/resources/customer/payments-tab.blade.php
+++ b/server/resources/views/filament/resources/customer/payments-tab.blade.php
@@ -1,0 +1,5 @@
+@livewire(
+    App\Filament\Resources\CustomerResource\RelationManagers\PaymentsRelationManager::class,
+    ['ownerRecord' => $record, 'pageClass' => $this::class],
+    key('payments-' . $record->getKey()),
+)


### PR DESCRIPTION
## Issue #22 — Customers > More Tabs

Surfaces a customer's related records as tabs on the Customer edit screen. Builds on the existing Properties/Invoices relation-manager-in-tab pattern.

### New tabs
- **Jobs** — searchable, status-filterable table of the customer's jobs, a **New Job** header action (modal quick-add with the property scoped to this customer), and a **Details** link to the full job.
- **Estimates** — table with the estimate # linked to its detail view, status filter, and a **View** action opening the same public page the client sees (`share_token`).
- **Payments** — table filterable by method and paid date, each row linking to its invoice.

### Supporting change
- `Customer::payments()` HasMany relation added to back the Payments tab.
- **Invoices** tab is unchanged.

### Verified
- All files lint clean.
- `payments` relation resolves; `Payment::METHODS` present; the `estimates.edit`, `jobs.edit`, and `invoices.edit` routes all exist.
- New tabs follow the exact `View::make(... )` + relation-manager embed convention already used for Properties/Invoices.

> Note: kept intentionally decoupled from #28 (job `price`) — the New Job modal here omits price so this PR is independent; price is available on the main Job resource once #28 merges.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)