### PR TITLE
Managed push-notification templates (#14)

### DIFF
--- a/server/app/Filament/Resources/NotificationTemplateResource.php
+++ b/server/app/Filament/Resources/NotificationTemplateResource.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Concerns\ChecksResourceAccess;
+use App\Filament\Resources\NotificationTemplateResource\Pages;
+use App\Models\NotificationTemplate;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
+
+class NotificationTemplateResource extends Resource
+{
+    use ChecksResourceAccess;
+
+    protected static ?string $model = NotificationTemplate::class;
+
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-bell-alert';
+
+    protected static string | \UnitEnum | null $navigationGroup = 'Administration';
+
+    protected static ?int $navigationSort = 4;
+
+    protected static ?string $navigationLabel = 'Push Notifications';
+
+    protected static ?string $modelLabel = 'notification template';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255)
+                ->helperText('A label so you can recognise this notification.'),
+            Forms\Components\TextInput::make('key')
+                ->label('Key')
+                ->required()
+                ->maxLength(255)
+                // The app sends notifications against this key — locked once created.
+                ->disabled(fn (?NotificationTemplate $record): bool => $record !== null)
+                ->dehydrated()
+                ->unique(ignoreRecord: true)
+                ->helperText('Machine key the app references (e.g. job_skipped). Cannot be changed after creation.'),
+            Forms\Components\TextInput::make('title')
+                ->required()
+                ->maxLength(255)
+                ->helperText('Push notification title. Placeholders allowed.'),
+            Forms\Components\Textarea::make('body')
+                ->required()
+                ->rows(3)
+                ->helperText('Push notification body. Placeholders allowed.'),
+            Forms\Components\Select::make('channel')
+                ->options([
+                    'default' => 'Default',
+                    'alerts' => 'Alerts',
+                    'chat' => 'Chat',
+                ])
+                ->default('alerts')
+                ->required(),
+            Forms\Components\Toggle::make('is_active')
+                ->label('Active')
+                ->default(true)
+                ->helperText('When off, the app falls back to its built-in default text.'),
+            Forms\Components\Placeholder::make('placeholders')
+                ->label('Available placeholders')
+                ->content(new HtmlString(
+                    collect(NotificationTemplate::PLACEHOLDERS)
+                        ->map(fn ($desc, $token) => '<code>' . e($token) . '</code> — ' . e($desc))
+                        ->implode('<br>')
+                ))
+                ->columnSpanFull(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('key')
+                    ->badge()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('title')
+                    ->limit(40),
+                Tables\Columns\TextColumn::make('channel')
+                    ->badge()
+                    ->toggleable(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([])
+            ->defaultPaginationPageOption(50)
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListNotificationTemplates::route('/'),
+            'create' => Pages\CreateNotificationTemplate::route('/create'),
+            'edit' => Pages\EditNotificationTemplate::route('/{record}/edit'),
+        ];
+    }
+}

--- a/server/app/Filament/Resources/NotificationTemplateResource/Pages/CreateNotificationTemplate.php
+++ b/server/app/Filament/Resources/NotificationTemplateResource/Pages/CreateNotificationTemplate.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\NotificationTemplateResource\Pages;
+
+use App\Filament\Resources\NotificationTemplateResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateNotificationTemplate extends CreateRecord
+{
+    protected static string $resource = NotificationTemplateResource::class;
+}

--- a/server/app/Filament/Resources/NotificationTemplateResource/Pages/EditNotificationTemplate.php
+++ b/server/app/Filament/Resources/NotificationTemplateResource/Pages/EditNotificationTemplate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\NotificationTemplateResource\Pages;
+
+use App\Filament\Resources\NotificationTemplateResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditNotificationTemplate extends EditRecord
+{
+    protected static string $resource = NotificationTemplateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [Actions\DeleteAction::make()];
+    }
+}

--- a/server/app/Filament/Resources/NotificationTemplateResource/Pages/ListNotificationTemplates.php
+++ b/server/app/Filament/Resources/NotificationTemplateResource/Pages/ListNotificationTemplates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\NotificationTemplateResource\Pages;
+
+use App\Filament\Resources\NotificationTemplateResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListNotificationTemplates extends ListRecords
+{
+    protected static string $resource = NotificationTemplateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/server/app/Models/NotificationTemplate.php
+++ b/server/app/Models/NotificationTemplate.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NotificationTemplate extends Model
+{
+    protected $table = 'notification_templates';
+
+    protected $fillable = [
+        'key',
+        'name',
+        'title',
+        'body',
+        'channel',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * Placeholders an admin may use in a template, with a short description.
+     * Shown as helper text on the resource form.
+     *
+     * @var array<string, string>
+     */
+    public const PLACEHOLDERS = [
+        '{customer_name}' => "The customer's name",
+        '{client_name}' => "Alias for {customer_name}",
+        '{job_title}' => 'The job title',
+        '{scheduled_date}' => "The job's scheduled date (e.g. Mon, Jun 22)",
+        '{crew_name}' => 'The assigned crew',
+        '{status}' => 'The job status (skipped / canceled)',
+        '{address}' => 'The property address',
+        '{city}' => 'The property city',
+    ];
+
+    /**
+     * Substitute {placeholders} in a string from a vars map.
+     *
+     * @param  array<string, string|null>  $vars  Keys without braces, e.g. ['job_title' => '...'].
+     */
+    public static function substitute(string $text, array $vars): string
+    {
+        $replacements = [];
+        foreach ($vars as $key => $value) {
+            $replacements['{' . $key . '}'] = (string) ($value ?? '');
+        }
+
+        return strtr($text, $replacements);
+    }
+
+    /**
+     * Render an active template by key into a title/body pair, or null if the
+     * template is missing or disabled (callers fall back to default copy).
+     *
+     * @param  array<string, string|null>  $vars
+     * @return array{title: string, body: string, channel: string}|null
+     */
+    public static function render(string $key, array $vars): ?array
+    {
+        $template = static::where('key', $key)->where('is_active', true)->first();
+        if (! $template) {
+            return null;
+        }
+
+        return [
+            'title' => static::substitute($template->title, $vars),
+            'body' => static::substitute($template->body, $vars),
+            'channel' => $template->channel ?: 'alerts',
+        ];
+    }
+}

--- a/server/app/Services/JobNotifier.php
+++ b/server/app/Services/JobNotifier.php
@@ -56,8 +56,31 @@ class JobNotifier
         $date = $scheduledDate ?? $job->scheduled_date?->toDateString();
         $when = $date ? Carbon::parse($date)->format('D, M j') : 'an upcoming day';
 
-        $title = 'Job ' . $verb;
-        $body = ($job->title ?: 'A job') . ' (' . $when . ') was ' . $verb . '.';
+        // Build the placeholder values an admin can reference in the template (issue #14).
+        $job->loadMissing(['customer', 'property']);
+        $customer = $job->customer;
+        $customerName = $customer
+            ? (trim(($customer->first_name ?? '') . ' ' . ($customer->last_name ?? ''))
+                ?: ($customer->company_name ?? 'the customer'))
+            : 'the customer';
+
+        $vars = [
+            'customer_name' => $customerName,
+            'client_name' => $customerName,
+            'job_title' => $job->title ?: 'A job',
+            'scheduled_date' => $when,
+            'crew_name' => $crew->name,
+            'status' => $verb,
+            'address' => $job->property?->address ?? '',
+            'city' => $job->property?->city ?? '',
+        ];
+
+        // Prefer the admin-managed template; fall back to built-in copy when it's
+        // missing or disabled.
+        $rendered = \App\Models\NotificationTemplate::render('job_' . $status, $vars);
+        $title = $rendered['title'] ?? ('Job ' . $verb);
+        $body = $rendered['body'] ?? (($job->title ?: 'A job') . ' (' . $when . ') was ' . $verb . '.');
+        $channel = $rendered['channel'] ?? 'alerts';
 
         foreach ($recipients as $employee) {
             $this->push->sendToEmployee(
@@ -65,7 +88,7 @@ class JobNotifier
                 $title,
                 $body,
                 ['type' => 'job', 'job_id' => $job->id, 'status' => $status],
-                'alerts',
+                $channel,
             );
         }
     }

--- a/server/database/migrations/2026_06_18_000008_create_notification_templates_table.php
+++ b/server/database/migrations/2026_06_18_000008_create_notification_templates_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();   // machine key the app sends against
+            $table->string('name');            // human label
+            $table->string('title');           // push title (supports {placeholders})
+            $table->text('body');              // push body (supports {placeholders})
+            $table->string('channel')->default('alerts');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        // Seed the job skip/cancel templates (issue #14). Existing hardcoded copy
+        // is preserved as the default text, now editable by an admin.
+        $defaults = [
+            [
+                'key' => 'job_skipped',
+                'name' => 'Job skipped',
+                'title' => 'Job skipped',
+                'body' => '{job_title} ({scheduled_date}) was skipped.',
+                'channel' => 'alerts',
+            ],
+            [
+                'key' => 'job_cancelled',
+                'name' => 'Job canceled',
+                'title' => 'Job canceled',
+                'body' => '{job_title} ({scheduled_date}) was canceled.',
+                'channel' => 'alerts',
+            ],
+        ];
+
+        foreach ($defaults as $row) {
+            DB::table('notification_templates')->updateOrInsert(
+                ['key' => $row['key']],
+                array_merge($row, ['is_active' => true, 'created_at' => now(), 'updated_at' => now()]),
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_templates');
+    }
+};


### PR DESCRIPTION
## Issue #14 — Native App > Push Notification

Lets admins manage push-notification copy (with dynamic placeholders) instead of it being hardcoded.

### Changes
- **Migration** `create_notification_templates_table` — `key`, `name`, `title`, `body`, `channel`, `is_active`; seeded with **job_skipped** and **job_cancelled** (preserving the current wording as the editable default).
- **`NotificationTemplate` model** — `PLACEHOLDERS` map, `substitute()` (token → value), and `render($key, $vars)` returning title/body/channel for an active template (or `null` to fall back).
- **`NotificationTemplateResource`** ("Push Notifications", Administration group) — CRUD with the available `{placeholders}` listed on the form; `key` is locked after creation since the app sends against it.
- **`JobNotifier`** — the existing skip/cancel alert to a crew's foreman + spray techs now renders from the template, filling `{customer_name}`/`{client_name}`, `{job_title}`, `{scheduled_date}`, `{crew_name}`, `{status}`, `{address}`, `{city}`. Falls back to built-in copy if the template is missing/disabled.

### Notes
- Builds on the existing `JobNotifier` + `ExpoPushService` (skip/cancel triggering was already wired from the Dispatch board); this PR makes the **text** editable, which was the core ask. Additional notification types can be added as new template rows + `render()` calls.

### Verified
- Migration runs; all files lint clean; resource caches via `filament:cache-components`.
- Render test: `render('job_skipped', {...})` → "Front lawn mow (Mon, Jun 22) was skipped."; unknown key → `null` (fallback path).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)