### PR TITLE
Accept Blue card/ACH charging on public invoice pay (#27)

### DIFF
--- a/server/app/Http/Controllers/PublicInvoiceController.php
+++ b/server/app/Http/Controllers/PublicInvoiceController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Invoice;
+use App\Models\Payment;
+use App\Services\AcceptBluePaymentService;
 use Illuminate\Http\Request;
 
 class PublicInvoiceController extends Controller
@@ -16,7 +18,7 @@ class PublicInvoiceController extends Controller
         return view('invoices.public', compact('invoice'));
     }
 
-    public function pay(string $token, Request $request)
+    public function pay(string $token, Request $request, AcceptBluePaymentService $gateway)
     {
         $invoice = Invoice::where('share_token', $token)->firstOrFail();
 
@@ -24,16 +26,35 @@ class PublicInvoiceController extends Controller
             return redirect()->back();
         }
 
-        $method = $request->input('payment_method', 'card');
-        $isPaymentPlan = $request->boolean('payment_plan');
+        $validated = $request->validate([
+            'source_token' => ['required', 'string'],
+            'payment_type' => ['nullable', 'in:card,ach'],
+            'payment_plan' => ['nullable', 'boolean'],
+        ]);
+
+        $type = $validated['payment_type'] ?? 'card';
+        $method = $type === 'ach' ? 'ach' : 'card';
+        $isPaymentPlan = (bool) ($validated['payment_plan'] ?? false);
 
         if ($isPaymentPlan) {
-            // Enroll in 12-installment payment plan via credit card
-            // 3.75% CC fee applied to each installment
+            // First installment of a 12-payment plan; 3.75% CC fee per installment.
             $installments = 12;
             $feeRate = 0.0375;
             $baseInstallment = round($invoice->total / $installments, 2);
             $installmentWithFee = round($baseInstallment * (1 + $feeRate), 2);
+
+            $result = $gateway->charge($invoice, $validated['source_token'], $installmentWithFee, $type);
+            if (! $result['success']) {
+                return redirect()->back()->with('error', $this->declineMessage($result['error']));
+            }
+
+            Payment::create([
+                'invoice_id' => $invoice->id,
+                'amount' => $installmentWithFee,
+                'method' => $method,
+                'reference' => $result['transaction_id'],
+                'notes' => 'Payment plan installment 1 of ' . $installments . ' (Accept Blue)',
+            ]);
 
             $invoice->update([
                 'is_payment_plan' => true,
@@ -43,28 +64,44 @@ class PublicInvoiceController extends Controller
                 'payment_plan_started_at' => now(),
                 'payment_plan_payments_made' => 1,
                 'status' => 'payment_plan',
-                'notes' => trim(
-                    ($invoice->notes ?? '') .
-                    "\n\n--- Payment plan enrolled on " . now()->format('M j, Y g:i A') .
-                    "\n{$installments} payments of \${$installmentWithFee} every 30 days (includes 3.75% CC fee)" .
-                    "\nFirst payment processed via credit card"
-                ),
             ]);
 
             return redirect()->back()->with('success',
-                "Payment plan enrolled! You will be charged \${$installmentWithFee} every 30 days for {$installments} payments."
+                "First payment of \${$installmentWithFee} received. You'll be charged \${$installmentWithFee} every 30 days for the remaining " . ($installments - 1) . ' payments.'
             );
         }
 
-        // One-time full payment
-        $invoice->update([
-            'status' => 'paid',
-            'paid_at' => now(),
-            'notes' => trim(
-                ($invoice->notes ?? '') . "\n\n--- Payment received via {$method} on " . now()->format('M j, Y g:i A')
-            ),
+        // One-time payment of the outstanding balance.
+        $amount = round($invoice->balanceDue(), 2);
+        if ($amount <= 0) {
+            return redirect()->back()->with('success', 'This invoice is already paid in full.');
+        }
+
+        $result = $gateway->charge($invoice, $validated['source_token'], $amount, $type);
+        if (! $result['success']) {
+            return redirect()->back()->with('error', $this->declineMessage($result['error']));
+        }
+
+        Payment::create([
+            'invoice_id' => $invoice->id,
+            'amount' => $amount,
+            'method' => $method,
+            'reference' => $result['transaction_id'],
+            'notes' => 'Paid online (Accept Blue)',
         ]);
 
+        // Recompute against payments; mark paid once the balance is cleared.
+        if ($invoice->fresh()->balanceDue() <= 0) {
+            $invoice->update(['status' => 'paid', 'paid_at' => now()]);
+        }
+
         return redirect()->back()->with('success', 'Payment received — thank you!');
+    }
+
+    private function declineMessage(?string $error): string
+    {
+        return $error
+            ? 'Payment could not be completed: ' . $error
+            : 'Payment could not be completed. Please try again or use a different card.';
     }
 }

--- a/server/app/Services/AcceptBluePaymentService.php
+++ b/server/app/Services/AcceptBluePaymentService.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Invoice;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+/**
+ * Charges invoices through Accept Blue (issue #27).
+ *
+ * Card data is never handled here — the public pay page tokenizes the card via
+ * Accept Blue's hosted fields and only the resulting token/nonce reaches the
+ * server, which we charge against. The `mode` config decides sandbox vs live so
+ * test charges never touch the production gateway.
+ */
+class AcceptBluePaymentService
+{
+    /**
+     * Charge a tokenized card / ACH source for an invoice.
+     *
+     * @param  string  $sourceToken  Nonce/token produced by the hosted fields.
+     * @param  string  $type         'card' or 'ach'.
+     * @return array{success: bool, transaction_id: ?string, status: ?string, error: ?string}
+     */
+    public function charge(Invoice $invoice, string $sourceToken, float $amount, string $type = 'card'): array
+    {
+        try {
+            $endpoint = $this->endpoint();
+        } catch (RuntimeException $e) {
+            return $this->failure($e->getMessage());
+        }
+
+        if ($sourceToken === '' || $amount <= 0) {
+            return $this->failure('Missing payment token or amount.');
+        }
+
+        $payload = [
+            'amount' => round($amount, 2),
+            'source' => $sourceToken,
+            'capture' => true,
+            'reference' => $invoice->invoice_number,
+            'transaction_details' => [
+                'description' => 'Invoice ' . $invoice->invoice_number,
+            ],
+        ];
+
+        try {
+            $response = Http::withHeaders([
+                'Authorization' => $this->authorizationHeader(),
+                'Accept' => 'application/json',
+            ])
+                ->timeout(20)
+                ->post(rtrim($endpoint, '/') . '/transactions/charge', $payload);
+        } catch (\Throwable $e) {
+            Log::error('Accept Blue charge request failed: ' . $e->getMessage());
+
+            return $this->failure('Could not reach the payment processor. Please try again.');
+        }
+
+        $body = $response->json() ?? [];
+
+        if (! $response->successful()) {
+            $message = $body['error_message'] ?? $body['message'] ?? 'Payment was declined.';
+            Log::warning('Accept Blue charge non-2xx', ['status' => $response->status(), 'body' => $body]);
+
+            return $this->failure((string) $message, $this->extractStatus($body));
+        }
+
+        $status = $this->extractStatus($body);
+        $approved = in_array(strtolower((string) $status), ['approved', 'partially_approved', 'success'], true);
+
+        if (! $approved) {
+            $message = $body['error_message'] ?? $body['decline_reason'] ?? 'Payment was not approved.';
+
+            return $this->failure((string) $message, $status);
+        }
+
+        return [
+            'success' => true,
+            'transaction_id' => $this->extractTransactionId($body),
+            'status' => $status,
+            'error' => null,
+        ];
+    }
+
+    public function isLive(): bool
+    {
+        return config('services.accept_blue.mode') === 'live';
+    }
+
+    /** Resolve the API base URL for the active mode; refuse to fall back to live in sandbox mode. */
+    private function endpoint(): string
+    {
+        if ($this->isLive()) {
+            $endpoint = config('services.accept_blue.endpoint');
+            if (! $endpoint) {
+                throw new RuntimeException('Accept Blue live endpoint is not configured.');
+            }
+
+            return $endpoint;
+        }
+
+        $endpoint = config('services.accept_blue.sandbox_endpoint');
+        if (! $endpoint) {
+            throw new RuntimeException('Accept Blue sandbox endpoint is not configured (ACCEPT_BLUE_SANDBOX_ENDPOINT).');
+        }
+
+        return $endpoint;
+    }
+
+    private function authorizationHeader(): string
+    {
+        $token = config('services.accept_blue.auth_token');
+        if ($token) {
+            return 'Basic ' . $token;
+        }
+
+        $apiKey = (string) config('services.accept_blue.api_key');
+        $sourceKey = (string) config('services.accept_blue.source_key');
+
+        return 'Basic ' . base64_encode($apiKey . ':' . $sourceKey);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function extractStatus(array $body): ?string
+    {
+        return $body['status']
+            ?? $body['transaction']['status']
+            ?? $body['result']
+            ?? null;
+    }
+
+    /** @param array<string, mixed> $body */
+    private function extractTransactionId(array $body): ?string
+    {
+        $id = $body['transaction']['id']
+            ?? $body['transaction_id']
+            ?? $body['id']
+            ?? null;
+
+        return $id !== null ? (string) $id : null;
+    }
+
+    /** @return array{success: bool, transaction_id: null, status: ?string, error: string} */
+    private function failure(string $error, ?string $status = null): array
+    {
+        return [
+            'success' => false,
+            'transaction_id' => null,
+            'status' => $status,
+            'error' => $error,
+        ];
+    }
+}

--- a/server/config/services.php
+++ b/server/config/services.php
@@ -39,4 +39,22 @@ return [
         'maps_key' => env('GOOGLE_MAPS_API_KEY'),
     ],
 
+    /*
+    | Accept Blue (via the Reliable Payments broker) — invoice card/ACH charging.
+    | `mode` gates which endpoint is used so test charges never hit production:
+    | in 'sandbox' mode the SANDBOX_ENDPOINT must be set explicitly, otherwise a
+    | charge is refused rather than falling back to the live endpoint.
+    */
+    'accept_blue' => [
+        'mode' => env('ACCEPT_BLUE_MODE', 'sandbox'), // 'sandbox' | 'live'
+        'endpoint' => env('ACCEPT_BLUE_ENDPOINT'),
+        'sandbox_endpoint' => env('ACCEPT_BLUE_SANDBOX_ENDPOINT'),
+        'api_key' => env('ACCEPT_BLUE_API_KEY'),
+        'source_key' => env('ACCEPT_BLUE_SOURCE_KEY'), // "pin"/source key = Basic auth password
+        'auth_token' => env('ACCEPT_BLUE_AUTH_TOKEN'),  // pre-encoded Basic token (optional shortcut)
+        // Public tokenization key + script for the hosted card fields on the pay page.
+        'tokenization_key' => env('ACCEPT_BLUE_TOKENIZATION_KEY'),
+        'tokenization_src' => env('ACCEPT_BLUE_TOKENIZATION_SRC'),
+    ],
+
 ];

--- a/server/resources/views/invoices/public.blade.php
+++ b/server/resources/views/invoices/public.blade.php
@@ -242,50 +242,43 @@
                                 <button class="pay-tab" onclick="switchPayTab('ach')" id="tab-ach">ACH / Bank</button>
                             </div>
 
+                            @php $tokenizerReady = filled(config('services.accept_blue.tokenization_key')) && filled(config('services.accept_blue.tokenization_src')); @endphp
+
+                            @if(session('error'))
+                                <div class="flash" style="background:#fee2e2;color:#991b1b;">{{ session('error') }}</div>
+                            @endif
+
                             <form id="pay-form" method="POST" action="{{ route('invoice.pay', $invoice->share_token) }}">
                                 @csrf
-                                <input type="hidden" name="payment_method" id="payment-method" value="card">
+                                <input type="hidden" name="payment_type" id="payment-method" value="card">
                                 <input type="hidden" name="payment_plan" id="payment-plan-input" value="0">
+                                {{-- Filled client-side by the Accept Blue hosted tokenizer; the raw card never touches our server. --}}
+                                <input type="hidden" name="source_token" id="source-token" value="">
 
-                                {{-- Credit Card fields --}}
+                                {{-- Credit Card (hosted fields) --}}
                                 <div id="card-fields">
                                     <div class="pay-field">
-                                        <label>Name on Card</label>
-                                        <input type="text" name="card_name" placeholder="John Doe" required>
-                                    </div>
-                                    <div class="pay-field">
-                                        <label>Card Number</label>
-                                        <input type="text" name="card_number" placeholder="4242 4242 4242 4242" maxlength="19" required>
-                                    </div>
-                                    <div class="pay-row">
-                                        <div class="pay-field">
-                                            <label>Expiration</label>
-                                            <input type="text" name="card_exp" placeholder="MM / YY" maxlength="7" required>
-                                        </div>
-                                        <div class="pay-field">
-                                            <label>CVC</label>
-                                            <input type="text" name="card_cvc" placeholder="123" maxlength="4" required>
-                                        </div>
+                                        <label>Card details</label>
+                                        {{-- Accept Blue hosted fields mount into this element. --}}
+                                        <div id="accept-blue-card" style="padding:12px;border:1px solid #d1d5db;border-radius:8px;min-height:44px;"></div>
                                     </div>
                                 </div>
 
-                                {{-- ACH fields --}}
+                                {{-- ACH (hosted fields) --}}
                                 <div id="ach-fields" style="display: none;">
                                     <div class="pay-field">
-                                        <label>Account Holder Name</label>
-                                        <input type="text" name="ach_name" placeholder="John Doe">
-                                    </div>
-                                    <div class="pay-field">
-                                        <label>Routing Number</label>
-                                        <input type="text" name="ach_routing" placeholder="021000021" maxlength="9">
-                                    </div>
-                                    <div class="pay-field">
-                                        <label>Account Number</label>
-                                        <input type="text" name="ach_account" placeholder="000123456789">
+                                        <label>Bank account details</label>
+                                        <div id="accept-blue-ach" style="padding:12px;border:1px solid #d1d5db;border-radius:8px;min-height:44px;"></div>
                                     </div>
                                 </div>
 
-                                <button type="submit" class="btn-pay" id="btn-pay">
+                                @unless($tokenizerReady)
+                                    <div class="flash" style="background:#fef3c7;color:#92400e;">
+                                        Online payment isn't fully configured yet. Add your Accept Blue tokenization key to enable card &amp; ACH payments.
+                                    </div>
+                                @endunless
+
+                                <button type="submit" class="btn-pay" id="btn-pay" @unless($tokenizerReady) disabled style="opacity:.6;cursor:not-allowed;" @endunless>
                                     Pay ${{ number_format($invoice->total, 2) }}
                                 </button>
                             </form>
@@ -357,6 +350,65 @@
                             updatePayButton();
                         });
                     </script>
+
+                    @if($tokenizerReady)
+                        {{-- Accept Blue hosted tokenization: card data is entered in Accept Blue's
+                             iframe fields and exchanged for a one-time token, which is the only thing
+                             submitted to our server (issue #27). --}}
+                        <script src="{{ config('services.accept_blue.tokenization_src') }}"></script>
+                        <script>
+                            (function () {
+                                const cfg = @json(['key' => config('services.accept_blue.tokenization_key')]);
+                                const form = document.getElementById('pay-form');
+                                const tokenInput = document.getElementById('source-token');
+                                const btn = document.getElementById('btn-pay');
+                                let hostedCard = null;
+
+                                // Accept Blue exposes a hosted-tokenization global once its script loads.
+                                // The exact constructor name can vary by account; guard for it so a
+                                // misconfiguration surfaces clearly instead of silently failing.
+                                const AB = window.AcceptBlue || window.HostedTokenization || null;
+
+                                function init() {
+                                    if (!AB) return;
+                                    try {
+                                        hostedCard = new AB({ key: cfg.key });
+                                        if (typeof hostedCard.mount === 'function') {
+                                            hostedCard.mount('#accept-blue-card');
+                                        }
+                                    } catch (e) { console.error('Accept Blue init failed', e); }
+                                }
+
+                                form.addEventListener('submit', function (e) {
+                                    // Already tokenized on a prior pass — let it through.
+                                    if (tokenInput.value) return;
+
+                                    e.preventDefault();
+                                    if (!AB || !hostedCard || typeof hostedCard.getNonce !== 'function') {
+                                        alert('Payment is not available right now. Please try again later.');
+                                        return;
+                                    }
+
+                                    btn.disabled = true;
+                                    btn.textContent = 'Processing…';
+
+                                    hostedCard.getNonce()
+                                        .then(function (nonce) {
+                                            tokenInput.value = (nonce && (nonce.token || nonce.nonce)) || nonce;
+                                            form.submit();
+                                        })
+                                        .catch(function (err) {
+                                            btn.disabled = false;
+                                            updatePayButton();
+                                            alert((err && err.message) || 'Could not verify your card. Please check the details and try again.');
+                                        });
+                                });
+
+                                if (document.readyState !== 'loading') init();
+                                else document.addEventListener('DOMContentLoaded', init);
+                            })();
+                        </script>
+                    @endif
 
                 @elseif($invoice->status === 'payment_plan')
                     <div style="margin-top: 24px; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 10px; padding: 20px;">


### PR DESCRIPTION
## Issue #27 — Invoices > Send + Pay

Makes the public invoice pay page actually **charge** through Accept Blue instead of just flipping the invoice to `paid`. Card data is tokenized client-side (hosted fields) so raw PANs never reach our server. (The "Send" side — `ShareInvoiceMail` — already existed.)

### Changes
- **`config/services.php`** — `accept_blue` block. A `mode` gate (`sandbox` | `live`) selects the endpoint; **in sandbox mode a dedicated `ACCEPT_BLUE_SANDBOX_ENDPOINT` must be set** or a charge is refused — test charges can never fall through to the production endpoint.
- **`AcceptBluePaymentService`** — charges a tokenized source via `{endpoint}/transactions/charge`, normalises approve/decline/error into a result array, logs failures, and never throws to the caller.
- **`PublicInvoiceController::pay()`** — requires a `source_token`, charges the outstanding balance (or the first payment-plan installment), records a `Payment` on success, and marks the invoice `paid` once the balance clears. Declines return a friendly message.
- **`invoices/public.blade.php`** — raw card inputs replaced with Accept Blue hosted-field mounts + tokenizer flow (submits only the token); pay button disabled with a notice until the tokenization key is set.

### Safety / verification
- Endpoint is **production**, so I did **not** fire real charges. Verified with a **faked** gateway:
  - approved → `Payment` created (`ref=txn`), invoice → `paid`, balance $0
  - declined (200 w/ decline) and non-2xx (402) → `success=false` with the gateway message, invoice untouched
  - sandbox mode w/o sandbox endpoint → refused (never hits live)
- All files lint clean; all Blade templates compile.

### Go-live checklist (needs your sandbox creds)
Set in `.env`: `ACCEPT_BLUE_MODE=sandbox`, `ACCEPT_BLUE_SANDBOX_ENDPOINT=…`, `ACCEPT_BLUE_TOKENIZATION_KEY=…`, `ACCEPT_BLUE_TOKENIZATION_SRC=…` (and `ACCEPT_BLUE_SOURCE_KEY` if not using `AUTH_TOKEN`). Then run an Accept Blue **test card** through the pay page to confirm an end-to-end approval before flipping `ACCEPT_BLUE_MODE=live`.

> Note: the hosted-tokenizer JS uses a defensive adapter (`window.AcceptBlue`/`HostedTokenization` → `getNonce()`); confirm the exact global/method names against your Accept Blue hosted-tokenization account and adjust the adapter if they differ.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)