### PR TITLE
Customer app login with a real password

### DIFF
--- a/server/app/Filament/Resources/CustomerResource.php
+++ b/server/app/Filament/Resources/CustomerResource.php
@@ -48,6 +48,14 @@ class CustomerResource extends Resource
                             Forms\Components\TextInput::make('email')
                                 ->email()
                                 ->maxLength(255),
+                            Forms\Components\TextInput::make('password')
+                                ->label('App Password')
+                                ->password()
+                                ->revealable()
+                                ->helperText('Set or reset this customer\'s password for the mobile app. Leave blank to keep unchanged.')
+                                // Model hashes via the "hashed" cast; only save when a value is entered.
+                                ->dehydrated(fn (?string $state): bool => filled($state))
+                                ->maxLength(255),
                             Forms\Components\TextInput::make('phone')
                                 ->tel()
                                 ->maxLength(255),

--- a/server/app/Livewire/Mobile/MobileLogin.php
+++ b/server/app/Livewire/Mobile/MobileLogin.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Mobile;
 
 use App\Models\Customer;
 use App\Models\Employee;
+use Illuminate\Support\Facades\Hash;
 use Livewire\Component;
 
 class MobileLogin extends Component
@@ -104,32 +105,21 @@ class MobileLogin extends Component
             return;
         }
 
-        if ($this->password !== 'password') {
-            session()->flash('error', 'Invalid password. Use "password" for testing.');
-            return;
-        }
-
-        if ($this->selectedUserType === 'employee') {
-            $employee = Employee::find($this->selectedUserId);
-            if (!$employee) {
-                session()->flash('error', 'Employee not found.');
-                return;
-            }
-
-            $role = $employee->role ?: 'field';
-
-            session([
-                'mobile_app_user_id' => $employee->id,
-                'mobile_app_user_type' => 'employee',
-                'mobile_app_user_name' => trim(($employee->first_name ?? '') . ' ' . ($employee->last_name ?? '')) ?: $employee->name,
-                'mobile_app_employee_role' => $role,
-            ]);
-
-            $this->dispatch('user-logged-in');
-        } else {
+        if ($this->selectedUserType === 'customer') {
             $customer = Customer::find($this->selectedUserId);
             if (!$customer) {
                 session()->flash('error', 'Customer not found.');
+                return;
+            }
+
+            // Verify the customer's real app password once set; fall back to the
+            // demo password while none is configured so testing still works.
+            $valid = $customer->password
+                ? Hash::check($this->password, $customer->password)
+                : ($this->password === 'password');
+
+            if (!$valid) {
+                session()->flash('error', 'Invalid password.');
                 return;
             }
 
@@ -141,7 +131,31 @@ class MobileLogin extends Component
             ]);
 
             $this->dispatch('user-logged-in');
+            return;
         }
+
+        // Employees still use the shared demo password.
+        if ($this->password !== 'password') {
+            session()->flash('error', 'Invalid password. Use "password" for testing.');
+            return;
+        }
+
+        $employee = Employee::find($this->selectedUserId);
+        if (!$employee) {
+            session()->flash('error', 'Employee not found.');
+            return;
+        }
+
+        $role = $employee->role ?: 'field';
+
+        session([
+            'mobile_app_user_id' => $employee->id,
+            'mobile_app_user_type' => 'employee',
+            'mobile_app_user_name' => trim(($employee->first_name ?? '') . ' ' . ($employee->last_name ?? '')) ?: $employee->name,
+            'mobile_app_employee_role' => $role,
+        ]);
+
+        $this->dispatch('user-logged-in');
     }
 
     public function logout()

--- a/server/app/Models/Customer.php
+++ b/server/app/Models/Customer.php
@@ -21,6 +21,7 @@ class Customer extends Model
         'first_name',
         'last_name',
         'email',
+        'password',
         'phone',
         'address',
         'city',
@@ -40,10 +41,20 @@ class Customer extends Model
     /**
      * @return array<string, string>
      */
+    /**
+     * The attributes hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+    ];
+
     protected function casts(): array
     {
         return [
             'tags' => 'array',
+            'password' => 'hashed',
         ];
     }
 

--- a/server/database/migrations/2026_07_01_000003_add_password_to_customers_table.php
+++ b/server/database/migrations/2026_07_01_000003_add_password_to_customers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('customers', function (Blueprint $table) {
+            // App login password for the customer role (nullable — set by the office).
+            $table->string('password')->nullable()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('customers', function (Blueprint $table) {
+            $table->dropColumn('password');
+        });
+    }
+};


### PR DESCRIPTION
## Customer login foundation

Lets the office give a customer an app password so they can log into the native app as the **Customer** role. Direct answer to "add a password field to the Customers resource so they can login" + "not sure if auth actually works."

### Changes
- **Migration**: nullable `password` on `customers`.
- **Customer model**: `password` in `$fillable`, `hashed` cast, and `$hidden`.
- **Filament Customers resource**: an **App Password** field (revealable, only written when filled, hashed by the model cast — leave blank to keep unchanged).
- **MobileLogin**: customers now authenticate against their real password via `Hash::check`, with a fallback to the shared demo password **only while none is set** (so existing test logins still work). Employee login unchanged.

### Verified
- Migration runs; all files lint.
- Setting a password stores a bcrypt hash; `Hash::check` passes for the right password and rejects the wrong one; `MobileLogin` logs the customer in with the correct password; the demo fallback still works for customers without a password.

### Context / findings
- The mobile login was demo scaffolding (accepted the literal `password` for everyone). This makes **customer** auth real; hardening **employee** auth the same way is a sensible follow-up but out of scope here.
- The Customer app currently has Home/Jobs/Estimates/Profile views. Next up per the request: **Invoices** + **Payments** views, and a **customer ↔ admin chat** (the chat needs a small design decision on the admin reply surface — I'll raise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)