### PR TITLE
Dispatch: Month view + list card actions + explicit weekday

### DIFF
--- a/server/app/Livewire/DispatchBoard.php
+++ b/server/app/Livewire/DispatchBoard.php
@@ -104,7 +104,8 @@ class DispatchBoard extends Component
         // Restore this user's saved crew visibility + view mode (issue #24).
         $prefs = $user->dispatch_preferences ?? [];
         $this->hiddenCrewIds = array_values(array_map('intval', $prefs['hidden_crews'] ?? []));
-        $this->viewMode = ($prefs['view_mode'] ?? 'map') === 'list' ? 'list' : 'map';
+        $storedMode = $prefs['view_mode'] ?? 'map';
+        $this->viewMode = in_array($storedMode, ['map', 'list', 'month'], true) ? $storedMode : 'map';
         $this->listRange = ($prefs['list_range'] ?? 'day') === 'week' ? 'week' : 'day';
     }
 
@@ -710,6 +711,91 @@ class DispatchBoard extends Component
         return $days;
     }
 
+    /** Human label for the Month grid, e.g. "July 2026". */
+    #[Computed]
+    public function monthLabel(): string
+    {
+        return Carbon::parse($this->date)->format('F Y');
+    }
+
+    /**
+     * Calendar grid (whole weeks, Sun–Sat) for the month containing the selected
+     * date, with the number of scheduled stops per day so the office can see the
+     * month's workload at a glance and drill into any day.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    #[Computed]
+    public function monthDays(): array
+    {
+        $anchor = Carbon::parse($this->date)->startOfMonth();
+        $gridStart = $anchor->copy()->startOfWeek(Carbon::SUNDAY);
+        $gridEnd = $anchor->copy()->endOfMonth()->endOfWeek(Carbon::SATURDAY);
+
+        $hidden = array_map('intval', $this->hiddenCrewIds);
+
+        // Stops per day (respecting the active + hidden crew filters).
+        $counts = RouteStop::query()
+            ->join('routes', 'routes.id', '=', 'route_stops.route_id')
+            ->whereBetween('routes.route_date', [$gridStart->toDateString(), $gridEnd->toDateString()])
+            ->when(! empty($this->crewIds), fn ($q) => $q->whereIn('routes.crew_id', $this->crewIds))
+            ->when(! empty($hidden), fn ($q) => $q->whereNotIn('routes.crew_id', $hidden))
+            ->selectRaw('DATE(routes.route_date) as d, COUNT(*) as c')
+            ->groupBy('d')
+            ->pluck('c', 'd');
+
+        $today = now()->toDateString();
+        $days = [];
+        $cursor = $gridStart->copy();
+
+        while ($cursor <= $gridEnd) {
+            $key = $cursor->toDateString();
+            $days[] = [
+                'date' => $key,
+                'day_num' => (int) $cursor->format('j'),
+                'in_month' => $cursor->month === $anchor->month,
+                'is_today' => $key === $today,
+                'is_selected' => $key === $this->date,
+                'count' => (int) ($counts[$key] ?? 0),
+            ];
+            $cursor->addDay();
+        }
+
+        return $days;
+    }
+
+    /**
+     * Cancel the job behind a stop: mark it cancelled, pull it off the route, and
+     * alert the crew's field staff (mirrors the Skip flow but for cancellations).
+     */
+    public function cancelStop(int $stopId): void
+    {
+        $stop = RouteStop::find($stopId);
+        if (! $stop) {
+            return;
+        }
+
+        if ($stop->job_id) {
+            $job = \App\Models\Job::find($stop->job_id);
+            $originalDate = $job?->scheduled_date?->toDateString();
+
+            \App\Models\Job::where('id', $stop->job_id)->update([
+                'status' => 'cancelled',
+                'scheduled_date' => null,
+            ]);
+
+            if ($job) {
+                $job->status = 'cancelled';
+                app(\App\Services\JobNotifier::class)->notifySkippedOrCancelled($job, 'cancelled', $originalDate);
+            }
+        }
+
+        $stop->delete();
+
+        unset($this->stops, $this->unroutedJobs, $this->selectedStop, $this->selectedUnroutedJob, $this->summary, $this->unmappedStops, $this->listDays);
+        $this->emitStopsUpdated();
+    }
+
     /** Does a stop match the List-view search box (customer / property / service)? */
     private function stopMatchesSearch(RouteStop $stop, string $needle): bool
     {
@@ -979,7 +1065,7 @@ class DispatchBoard extends Component
 
     public function setViewMode(string $mode): void
     {
-        $this->viewMode = $mode === 'list' ? 'list' : 'map';
+        $this->viewMode = in_array($mode, ['map', 'list', 'month'], true) ? $mode : 'map';
         $this->persistDispatchPrefs();
 
         $this->dispatch('dispatch:view-changed', mode: $this->viewMode);
@@ -987,6 +1073,24 @@ class DispatchBoard extends Component
             // Re-feed the markers so the map can (re)build with current data.
             $this->emitStopsUpdated();
         }
+    }
+
+    /** Jump to a specific day and drop into the List view (used by the Month grid). */
+    public function goToDay(string $date): void
+    {
+        $this->date = Carbon::parse($date)->toDateString();
+        $this->viewMode = 'list';
+        $this->selectedStopId = null;
+        $this->persistDispatchPrefs();
+        unset($this->listDays, $this->listRangeLabel);
+    }
+
+    /** Move the Month grid (and selected date) by whole months. */
+    public function shiftMonth(int $months): void
+    {
+        $this->date = Carbon::parse($this->date)->addMonthsNoOverflow($months)->toDateString();
+        unset($this->monthDays, $this->monthLabel, $this->listDays, $this->listRangeLabel);
+        $this->emitStopsUpdated();
     }
 
     /** Switch the List view between a single day and the full week (Mon–Sat). */
@@ -1089,7 +1193,7 @@ class DispatchBoard extends Component
         }
         $stop->save();
 
-        unset($this->stops, $this->selectedStop, $this->summary);
+        unset($this->stops, $this->selectedStop, $this->summary, $this->listDays);
         $this->emitStopsUpdated();
     }
 
@@ -1227,7 +1331,7 @@ class DispatchBoard extends Component
         $this->confirmSkipStopId = null;
         $this->selectedStopId = null;
 
-        unset($this->stops, $this->unroutedJobs, $this->selectedStop, $this->selectedUnroutedJob, $this->summary, $this->unmappedStops);
+        unset($this->stops, $this->unroutedJobs, $this->selectedStop, $this->selectedUnroutedJob, $this->summary, $this->unmappedStops, $this->listDays);
         $this->emitStopsUpdated();
     }
 

--- a/server/resources/views/livewire/dispatch-board.blade.php
+++ b/server/resources/views/livewire/dispatch-board.blade.php
@@ -132,13 +132,59 @@
         .dispatch-page .d-agenda-day.is-today .d-agenda-weekday { color: var(--d-accent); }
         .dispatch-page .d-agenda-cards { display: flex; flex-wrap: wrap; gap: 12px; min-width: 0; }
         .dispatch-page .d-job-card {
-            display: block; width: 250px; max-width: 100%; text-align: left;
-            font: inherit; cursor: pointer;
+            width: 250px; max-width: 100%;
             background: var(--d-card-bg); border: 1px solid var(--d-border);
-            border-radius: 12px; padding: 14px; text-decoration: none; color: var(--d-text);
+            border-radius: 12px; padding: 14px; color: var(--d-text);
             transition: box-shadow 120ms, border-color 120ms;
         }
         .dispatch-page .d-job-card:hover { border-color: var(--d-muted); box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+        .dispatch-page .d-job-card-open {
+            display: block; width: 100%; text-align: left; font: inherit;
+            background: none; border: 0; padding: 0; cursor: pointer; color: inherit;
+        }
+        .dispatch-page .d-job-card-actions {
+            display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px;
+            padding-top: 10px; border-top: 1px solid var(--d-border);
+        }
+        .dispatch-page .d-card-act {
+            font: inherit; font-size: 11px; font-weight: 600; cursor: pointer;
+            padding: 4px 9px; border-radius: 6px; border: 1px solid var(--d-border);
+            background: var(--d-card-bg); color: var(--d-text);
+        }
+        .dispatch-page .d-card-act:hover { background: var(--d-hover); }
+        .dispatch-page .d-card-act.complete:hover { border-color: #16a34a; color: #16a34a; }
+        .dispatch-page .d-card-act.progress:hover { border-color: #d97706; color: #d97706; }
+        .dispatch-page .d-card-act.skip:hover { border-color: #dc2626; color: #dc2626; }
+        .dispatch-page .d-card-act.cancel:hover { border-color: #dc2626; background: #dc2626; color: #fff; }
+
+        /* Month view calendar grid. */
+        .dispatch-page .d-month-head {
+            display: flex; align-items: center; justify-content: center; gap: 16px; margin-bottom: 12px;
+        }
+        .dispatch-page .d-month-label { font-size: 16px; font-weight: 700; min-width: 160px; text-align: center; }
+        .dispatch-page .d-month-grid {
+            display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px;
+        }
+        .dispatch-page .d-month-dow {
+            text-align: center; font-size: 11px; font-weight: 600; text-transform: uppercase;
+            letter-spacing: 0.05em; color: var(--d-muted); padding-bottom: 4px;
+        }
+        .dispatch-page .d-month-cell {
+            font: inherit; text-align: left; cursor: pointer; min-height: 78px;
+            background: var(--d-card-bg); border: 1px solid var(--d-border); border-radius: 10px;
+            padding: 8px; display: flex; flex-direction: column; gap: 6px; color: var(--d-text);
+            transition: border-color 120ms, box-shadow 120ms;
+        }
+        .dispatch-page .d-month-cell:hover { border-color: var(--d-accent); box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+        .dispatch-page .d-month-cell.is-out { opacity: 0.45; }
+        .dispatch-page .d-month-cell.is-today { border-color: var(--d-accent); }
+        .dispatch-page .d-month-cell.is-selected { box-shadow: 0 0 0 2px var(--d-accent); }
+        .dispatch-page .d-month-daynum { font-size: 13px; font-weight: 600; }
+        .dispatch-page .d-month-count {
+            font-size: 11px; font-weight: 600; align-self: flex-start;
+            background: color-mix(in srgb, var(--d-accent) 15%, transparent); color: var(--d-accent);
+            padding: 1px 8px; border-radius: 9999px;
+        }
         .dispatch-page .d-crew-badge {
             display: inline-block; font-size: 11px; font-weight: 700;
             padding: 2px 10px; border-radius: 9999px; margin-bottom: 10px;
@@ -388,6 +434,12 @@
                             class="d-btn"
                             @if ($this->date === $tomorrow) style="{{ $activeStyle }}" @endif
                         >Tomorrow</button>
+
+                        {{-- Explicit day-of-week so the selected day is unmistakable. --}}
+                        <div class="d-weekday" style="margin-left:8px; line-height:1.1;">
+                            <div style="font-size:15px; font-weight:700;">{{ \Carbon\Carbon::parse($this->date)->format('l') }}</div>
+                            <div style="font-size:12px; color:var(--d-muted);">{{ \Carbon\Carbon::parse($this->date)->format('M j, Y') }}</div>
+                        </div>
                     </div>
 
                     <div class="d-spacer"></div>
@@ -408,6 +460,13 @@
                             style="height:32px;border:none;border-radius:0;{{ $this->viewMode === 'list' ? 'background: var(--d-accent); color:#fff;' : '' }}"
                             title="List view"
                         >List</button>
+                        <button
+                            type="button"
+                            wire:click="setViewMode('month')"
+                            class="d-btn"
+                            style="height:32px;border:none;border-radius:0;{{ $this->viewMode === 'month' ? 'background: var(--d-accent); color:#fff;' : '' }}"
+                            title="Month view"
+                        >Month</button>
                     </div>
 
                     {{-- Day / Week range toggle — only meaningful in List view. --}}
@@ -543,24 +602,32 @@
                             @endif
                             <div class="d-agenda-cards">
                                 @forelse ($day['jobs'] as $card)
-                                    <button
-                                        type="button"
-                                        wire:click="openStopDetails({{ $card['id'] }})"
-                                        wire:key="job-card-{{ $card['id'] }}"
-                                        class="d-job-card"
-                                        title="View job details"
-                                    >
-                                        <span class="d-crew-badge" style="background: {{ $card['color'] }}1a; color: {{ $card['color'] }};">{{ $card['crew_name'] }}</span>
-                                        <div class="d-job-card-title">{{ $card['customer_name'] }}</div>
-                                        <div class="d-job-card-sub">{{ $card['address'] }}</div>
-                                        @if ($card['service_summary'])
-                                            <div class="d-job-card-sub">{{ $card['service_summary'] }}</div>
-                                        @endif
-                                        <div class="d-job-card-status">
-                                            <span class="d-dot {{ $card['status_kind'] }}"></span>
-                                            {{ $card['status_label'] }}
+                                    <div wire:key="job-card-{{ $card['id'] }}" class="d-job-card">
+                                        <button
+                                            type="button"
+                                            wire:click="openStopDetails({{ $card['id'] }})"
+                                            class="d-job-card-open"
+                                            title="View job details"
+                                        >
+                                            <span class="d-crew-badge" style="background: {{ $card['color'] }}1a; color: {{ $card['color'] }};">{{ $card['crew_name'] }}</span>
+                                            <div class="d-job-card-title">{{ $card['customer_name'] }}</div>
+                                            <div class="d-job-card-sub">{{ $card['address'] }}</div>
+                                            @if ($card['service_summary'])
+                                                <div class="d-job-card-sub">{{ $card['service_summary'] }}</div>
+                                            @endif
+                                            <div class="d-job-card-status">
+                                                <span class="d-dot {{ $card['status_kind'] }}"></span>
+                                                {{ $card['status_label'] }}
+                                            </div>
+                                        </button>
+                                        {{-- Quick actions (skip / cancel / etc.) right on the card. --}}
+                                        <div class="d-job-card-actions">
+                                            <button type="button" class="d-card-act complete" wire:click="markStopStatus({{ $card['id'] }}, 'completed')" title="Mark completed">Complete</button>
+                                            <button type="button" class="d-card-act progress" wire:click="markStopStatus({{ $card['id'] }}, 'in_progress')" title="Mark in progress">Start</button>
+                                            <button type="button" class="d-card-act skip" wire:click="requestSkip({{ $card['id'] }})" title="Skip this job">Skip</button>
+                                            <button type="button" class="d-card-act cancel" wire:click="cancelStop({{ $card['id'] }})" wire:confirm="Cancel this job? The crew's field staff will be notified." title="Cancel this job">Cancel</button>
                                         </div>
-                                    </button>
+                                    </div>
                                 @empty
                                     <div class="d-agenda-empty">No jobs scheduled.</div>
                                 @endforelse
@@ -573,6 +640,38 @@
                             <div class="d-list-empty">No jobs scheduled for this {{ $this->listRange === 'week' ? 'week' : 'day' }}.</div>
                         @endif
                     @endforelse
+                </div>
+            </div>
+            @elseif ($this->viewMode === 'month')
+            {{-- Month view: calendar of scheduled workload; click a day to drill into it. --}}
+            <div class="d-bar">
+                <div class="d-month-head">
+                    <button type="button" wire:click="shiftMonth(-1)" class="d-icon-btn" title="Previous month">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+                    </button>
+                    <span class="d-month-label">{{ $this->monthLabel }}</span>
+                    <button type="button" wire:click="shiftMonth(1)" class="d-icon-btn" title="Next month">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                    </button>
+                </div>
+                <div class="d-month-grid">
+                    @foreach (['Sun','Mon','Tue','Wed','Thu','Fri','Sat'] as $dow)
+                        <div class="d-month-dow">{{ $dow }}</div>
+                    @endforeach
+                    @foreach ($this->monthDays as $day)
+                        <button
+                            type="button"
+                            wire:click="goToDay('{{ $day['date'] }}')"
+                            wire:key="month-{{ $day['date'] }}"
+                            class="d-month-cell {{ $day['in_month'] ? '' : 'is-out' }} {{ $day['is_today'] ? 'is-today' : '' }} {{ $day['is_selected'] ? 'is-selected' : '' }}"
+                            title="View {{ \Carbon\Carbon::parse($day['date'])->format('l, M j') }}"
+                        >
+                            <span class="d-month-daynum">{{ $day['day_num'] }}</span>
+                            @if ($day['count'] > 0)
+                                <span class="d-month-count">{{ $day['count'] }} {{ \Illuminate\Support\Str::plural('job', $day['count']) }}</span>
+                            @endif
+                        </button>
+                    @endforeach
                 </div>
             </div>
             @else


### PR DESCRIPTION
## Dispatch enhancements

Builds on the Map/List views (#36) with a third layout and quicker list actions.

### Month view
- New **Month** layout: a calendar grid for the selected month showing the **number of scheduled stops per day** (respecting crew visibility/filter). Click any day to jump into it in List view.
- Prev/next month navigation; the chosen view persists per user alongside Map/List (`dispatch_preferences.view_mode` now accepts `month`).

### List card quick-actions
- Agenda cards now have inline actions: **Complete**, **Start** (in-progress), **Skip** (existing confirm modal), and **Cancel**.
- **Cancel** is new (`cancelStop`): marks the job `cancelled`, unschedules it, removes it from the route, and notifies the crew's foreman + spray techs via the existing `JobNotifier`. Status changes refresh the agenda immediately.

### Explicit day-of-week
- The selected day's weekday is shown prominently next to the date nav (e.g. **Monday** / Jul 1, 2026) so the active day is unmistakable in every view. (The List agenda already labels weekdays per day.)

### Verified
- Lint clean; all Blade templates compile.
- `monthDays()` returns a full 5–6 week grid ("July 2026", 31 in-month days, correct per-day job counts); `goToDay`/`shiftMonth` present.
- `cancelStop` end-to-end: job → `cancelled`, unscheduled, stop removed, foreman notified, no errors.

> Stacks on #36 (merged). Depends on the `dispatch_preferences` column already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)