### PR TITLE
Customer <-> admin chat (per-customer conversation)

### DIFF
--- a/server/app/Filament/Resources/CustomerResource/Pages/EditCustomer.php
+++ b/server/app/Filament/Resources/CustomerResource/Pages/EditCustomer.php
@@ -12,6 +12,16 @@ class EditCustomer extends EditRecord
 
     protected function getHeaderActions(): array
     {
-        return [Actions\DeleteAction::make()];
+        return [
+            Actions\Action::make('chat')
+                ->label('Chat')
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('gray')
+                ->modalHeading(fn (): string => 'Chat with ' . (trim(($this->record->first_name ?? '') . ' ' . ($this->record->last_name ?? '')) ?: ($this->record->company_name ?? 'customer')))
+                ->modalContent(fn () => view('filament.customer-chat-modal', ['customerId' => $this->record->id]))
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel('Close'),
+            Actions\DeleteAction::make(),
+        ];
     }
 }

--- a/server/app/Filament/Resources/JobResource/Pages/EditJob.php
+++ b/server/app/Filament/Resources/JobResource/Pages/EditJob.php
@@ -12,6 +12,20 @@ class EditJob extends EditRecord
 
     protected function getHeaderActions(): array
     {
-        return [Actions\DeleteAction::make()];
+        return [
+            // Chat with this job's customer, right from the job detail.
+            Actions\Action::make('chatCustomer')
+                ->label('Chat with customer')
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('gray')
+                ->visible(fn (): bool => $this->record->customer_id !== null)
+                ->modalHeading(fn (): string => 'Chat with ' . ($this->record->customer
+                    ? (trim(($this->record->customer->first_name ?? '') . ' ' . ($this->record->customer->last_name ?? '')) ?: ($this->record->customer->company_name ?? 'customer'))
+                    : 'customer'))
+                ->modalContent(fn () => view('filament.customer-chat-modal', ['customerId' => $this->record->customer_id]))
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel('Close'),
+            Actions\DeleteAction::make(),
+        ];
     }
 }

--- a/server/app/Livewire/CustomerChatPanel.php
+++ b/server/app/Livewire/CustomerChatPanel.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Customer;
+use App\Models\CustomerMessage;
+use Livewire\Component;
+
+/**
+ * The office side of the customer <-> office conversation. Rendered inside a
+ * chat modal opened from the Customer resource or a job's customer.
+ */
+class CustomerChatPanel extends Component
+{
+    public int $customerId;
+
+    public string $body = '';
+
+    public function mount(int $customerId): void
+    {
+        $this->customerId = $customerId;
+
+        // Opening the panel marks the customer's unread messages as read.
+        CustomerMessage::query()
+            ->where('customer_id', $this->customerId)
+            ->where('sender', CustomerMessage::SENDER_CUSTOMER)
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+    }
+
+    public function getCustomerProperty(): ?Customer
+    {
+        return Customer::find($this->customerId);
+    }
+
+    public function getMessagesProperty()
+    {
+        return CustomerMessage::query()
+            ->with('senderUser:id,name')
+            ->where('customer_id', $this->customerId)
+            ->orderBy('created_at')
+            ->limit(300)
+            ->get();
+    }
+
+    public function send(): void
+    {
+        $body = trim($this->body);
+        if ($body === '') {
+            return;
+        }
+
+        CustomerMessage::create([
+            'customer_id' => $this->customerId,
+            'sender' => CustomerMessage::SENDER_OFFICE,
+            'sender_user_id' => auth()->id(),
+            'body' => $body,
+        ]);
+
+        $this->body = '';
+    }
+
+    public function render()
+    {
+        return view('livewire.customer-chat-panel');
+    }
+}

--- a/server/app/Livewire/Mobile/Views/CustomerChatView.php
+++ b/server/app/Livewire/Mobile/Views/CustomerChatView.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Livewire\Mobile\Views;
+
+use App\Livewire\Mobile\Traits\HasMobileTranslations;
+use App\Models\Customer;
+use App\Models\CustomerMessage;
+use Livewire\Attributes\Reactive;
+use Livewire\Component;
+
+class CustomerChatView extends Component
+{
+    use HasMobileTranslations;
+
+    #[Reactive]
+    public string $deviceMode = 'phone';
+
+    public string $body = '';
+
+    public function mount(): void
+    {
+        $this->language = session('mobile_app_language', 'en');
+
+        // Mark office messages as read when the customer opens the chat.
+        if ($id = session('mobile_app_user_id')) {
+            CustomerMessage::query()
+                ->where('customer_id', $id)
+                ->where('sender', CustomerMessage::SENDER_OFFICE)
+                ->whereNull('read_at')
+                ->update(['read_at' => now()]);
+        }
+    }
+
+    public function getCustomerProperty(): ?Customer
+    {
+        $customerId = session('mobile_app_user_id');
+
+        return $customerId ? Customer::find($customerId) : null;
+    }
+
+    public function getMessagesProperty()
+    {
+        if (! $this->customer) {
+            return collect();
+        }
+
+        return CustomerMessage::where('customer_id', $this->customer->id)
+            ->orderBy('created_at')
+            ->limit(300)
+            ->get();
+    }
+
+    public function send(): void
+    {
+        $body = trim($this->body);
+        if ($body === '' || ! $this->customer) {
+            return;
+        }
+
+        CustomerMessage::create([
+            'customer_id' => $this->customer->id,
+            'sender' => CustomerMessage::SENDER_CUSTOMER,
+            'body' => $body,
+        ]);
+
+        $this->body = '';
+    }
+
+    public function render()
+    {
+        return view('livewire.mobile.views.customer-chat', [
+            't' => $this->translations,
+        ]);
+    }
+}

--- a/server/app/Models/Customer.php
+++ b/server/app/Models/Customer.php
@@ -71,4 +71,9 @@ class Customer extends Model
     {
         return $this->hasMany(Payment::class);
     }
+
+    public function customerMessages(): HasMany
+    {
+        return $this->hasMany(CustomerMessage::class);
+    }
 }

--- a/server/app/Models/CustomerMessage.php
+++ b/server/app/Models/CustomerMessage.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One message in a customer <-> office conversation. The thread is keyed by
+ * `customer_id`; `sender` is 'customer' or 'office'.
+ */
+class CustomerMessage extends Model
+{
+    public const SENDER_CUSTOMER = 'customer';
+    public const SENDER_OFFICE = 'office';
+
+    protected $fillable = [
+        'customer_id',
+        'sender',
+        'sender_user_id',
+        'body',
+        'read_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'read_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        // A customer -> office message raises the office bell (admins + managers),
+        // mirroring the foreman chat alert.
+        static::created(function (CustomerMessage $message): void {
+            if ($message->sender !== self::SENDER_CUSTOMER) {
+                return;
+            }
+
+            $message->notifyOfficeOfIncomingChat();
+        });
+    }
+
+    protected function notifyOfficeOfIncomingChat(): void
+    {
+        $customer = $this->customer;
+        $name = $customer
+            ? (trim(($customer->first_name ?? '') . ' ' . ($customer->last_name ?? '')) ?: ($customer->company_name ?? 'A customer'))
+            : 'A customer';
+
+        $recipients = User::whereHas('role', function ($q) {
+            $q->where('is_admin', true)->orWhere('name', 'manager');
+        })->get();
+
+        if ($recipients->isEmpty()) {
+            return;
+        }
+
+        $notification = \Filament\Notifications\Notification::make()
+            ->title('New message from ' . $name)
+            ->body(\Illuminate\Support\Str::limit($this->body, 120))
+            ->icon('heroicon-o-chat-bubble-left-right')
+            ->actions([
+                \Filament\Actions\Action::make('open')
+                    ->label('Open customer')
+                    ->url(route('filament.admin.resources.customers.edit', $this->customer_id))
+                    ->markAsRead(),
+            ]);
+
+        foreach ($recipients as $recipient) {
+            $notification->sendToDatabase($recipient);
+        }
+    }
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    public function senderUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'sender_user_id');
+    }
+}

--- a/server/database/migrations/2026_07_01_000004_create_customer_messages_table.php
+++ b/server/database/migrations/2026_07_01_000004_create_customer_messages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // One long conversation per customer between the customer and the office.
+        Schema::create('customer_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->string('sender');                 // 'customer' | 'office'
+            $table->foreignId('sender_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('body');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['customer_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_messages');
+    }
+};

--- a/server/resources/views/filament/customer-chat-modal.blade.php
+++ b/server/resources/views/filament/customer-chat-modal.blade.php
@@ -1,0 +1,1 @@
+@livewire('customer-chat-panel', ['customerId' => $customerId], key('customer-chat-' . $customerId))

--- a/server/resources/views/livewire/customer-chat-panel.blade.php
+++ b/server/resources/views/livewire/customer-chat-panel.blade.php
@@ -1,0 +1,34 @@
+<div>
+    <div style="display:flex; flex-direction:column; height:420px; max-height:60vh;">
+        {{-- Conversation --}}
+        <div style="flex:1; overflow-y:auto; padding:12px; background:#f9fafb; border:1px solid #e5e7eb; border-radius:10px; display:flex; flex-direction:column; gap:8px;">
+            @forelse ($this->messages as $message)
+                @php $mine = $message->sender === \App\Models\CustomerMessage::SENDER_OFFICE; @endphp
+                <div style="display:flex; {{ $mine ? 'justify-content:flex-end;' : 'justify-content:flex-start;' }}">
+                    <div style="max-width:78%; padding:8px 11px; border-radius:12px; font-size:13px; line-height:1.45; {{ $mine ? 'background:#c9092f; color:#fff; border-bottom-right-radius:4px;' : 'background:#fff; color:#111827; border:1px solid #e5e7eb; border-bottom-left-radius:4px;' }}">
+                        <div>{{ $message->body }}</div>
+                        <div style="font-size:10px; margin-top:3px; {{ $mine ? 'color:rgba(255,255,255,0.75);' : 'color:#9ca3af;' }}">
+                            {{ $mine ? ($message->senderUser?->name ?? 'Office') : 'Customer' }} · {{ $message->created_at?->format('M j, g:i A') }}
+                        </div>
+                    </div>
+                </div>
+            @empty
+                <div style="margin:auto; color:#9ca3af; font-size:13px; text-align:center;">
+                    No messages yet. Say hello to start the conversation.
+                </div>
+            @endforelse
+        </div>
+
+        {{-- Composer --}}
+        <form wire:submit="send" style="display:flex; gap:8px; margin-top:10px;">
+            <input
+                type="text"
+                wire:model="body"
+                placeholder="Type a message to the customer…"
+                autocomplete="off"
+                style="flex:1; padding:10px 12px; font-size:14px; border:1px solid #d1d5db; border-radius:8px; box-sizing:border-box;"
+            />
+            <button type="submit" style="padding:10px 18px; font-size:14px; font-weight:600; color:#fff; background:#c9092f; border:none; border-radius:8px; cursor:pointer;">Send</button>
+        </form>
+    </div>
+</div>

--- a/server/resources/views/livewire/mobile/mobile-app.blade.php
+++ b/server/resources/views/livewire/mobile/mobile-app.blade.php
@@ -96,6 +96,7 @@
                                 'customer_home' => ['icon' => 'home', 'labelKey' => 'home'],
                                 'customer_estimates' => ['icon' => 'document-text', 'labelKey' => 'estimates'],
                                 'customer_jobs' => ['icon' => 'briefcase', 'labelKey' => 'jobs'],
+                                'customer_chat' => ['icon' => 'chat', 'labelKey' => 'messages'],
                                 'customer_request' => ['icon' => 'plus-circle', 'labelKey' => 'request_service'],
                                 'customer_profile' => ['icon' => 'user', 'labelKey' => 'profile'],
                             ];
@@ -140,6 +141,9 @@
                         @break
                     @case('customer_jobs')
                         <livewire:mobile.views.customer-jobs-view :device-mode="$deviceMode" wire:key="view-customer-jobs" />
+                        @break
+                    @case('customer_chat')
+                        <livewire:mobile.views.customer-chat-view :device-mode="$deviceMode" wire:key="view-customer-chat" />
                         @break
                     @case('customer_profile')
                         <livewire:mobile.views.customer-profile-view :device-mode="$deviceMode" wire:key="view-customer-profile" />

--- a/server/resources/views/livewire/mobile/views/customer-chat.blade.php
+++ b/server/resources/views/livewire/mobile/views/customer-chat.blade.php
@@ -1,0 +1,40 @@
+<div class="flex flex-col h-full" style="height: calc(100vh - 220px); min-height: 360px;">
+    <div class="px-4 py-3 border-b border-gray-100 bg-white">
+        <h2 class="text-lg font-bold text-gray-900">{{ $t['messages'] ?? 'Messages' }}</h2>
+        <p class="text-xs text-gray-500">Chat with the Marshall's Lawn office</p>
+    </div>
+
+    {{-- Conversation --}}
+    <div class="flex-1 overflow-y-auto p-4 space-y-2 bg-gray-50">
+        @forelse($this->messages as $message)
+            @php $mine = $message->sender === \App\Models\CustomerMessage::SENDER_CUSTOMER; @endphp
+            <div class="flex {{ $mine ? 'justify-end' : 'justify-start' }}">
+                <div class="max-w-[80%] px-3 py-2 rounded-2xl text-sm leading-snug
+                    {{ $mine ? 'bg-brand-500 text-white rounded-br-sm' : 'bg-white text-gray-800 border border-gray-200 rounded-bl-sm' }}">
+                    <div>{{ $message->body }}</div>
+                    <div class="text-[10px] mt-1 {{ $mine ? 'text-white/70' : 'text-gray-400' }}">
+                        {{ $mine ? 'You' : 'Office' }} · {{ $message->created_at?->format('M j, g:i A') }}
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="flex-1 flex items-center justify-center text-center text-gray-400 text-sm py-12">
+                No messages yet. Send a note to the office below.
+            </div>
+        @endforelse
+    </div>
+
+    {{-- Composer --}}
+    <form wire:submit="send" class="p-3 bg-white border-t border-gray-100 flex gap-2">
+        <input
+            type="text"
+            wire:model="body"
+            placeholder="Type a message…"
+            autocomplete="off"
+            class="flex-1 px-4 py-2 border border-gray-300 rounded-full text-sm focus:outline-none focus:border-brand-500"
+        />
+        <button type="submit" class="bg-brand-500 text-white font-semibold px-5 rounded-full text-sm hover:bg-brand-600 transition-colors">
+            Send
+        </button>
+    </form>
+</div>


### PR DESCRIPTION
## Customer ↔ admin chat

A dedicated, ongoing conversation per customer between the customer and the office — mirroring the foreman chat, opened from a chat button/panel.

### Data + alerts
- **Migration + `CustomerMessage`** — one thread per `customer_id`, `sender` = `customer`|`office`. A **customer → office** message raises the office **bell** (admins + managers) linking to the customer, mirroring the foreman chat alert.

### Admin side (chat button → panel)
- **`CustomerChatPanel`** Livewire (conversation + composer). Opening it marks the customer's messages read; the office replies inline.
- Surfaced as a **chat modal** via:
  - a **Chat** button on the Customer edit page, and
  - a **Chat with customer** button on the **Job detail** (next to the customer).
- The **Messages** resource stays the global historical record; this is the focused per-customer surface.

### Customer app
- A **Chat** view (side-menu "Messages") where the customer messages the office and sees the whole thread.

### Verified
- Migration runs; all files lint; all Blade templates compile.
- Flow test: customer → office message creates the row and takes the admin bell 0 → 1; opening the office panel marks unread read; an office reply yields a 2-message thread.

### Notes
- Text-only for v1 (the foreman chat supports attachments; can add later).
- Independent of the still-open customer PRs (#44 login, #46 invoices/payments); touches `mobile-app.blade.php` in a different spot, so merge in any order (trivial adjacency at most).

🤖 Generated with [Claude Code](https://claude.com/claude-code)