### PR TITLE
Dispatch Month view: readable crew text + New Job spacing

### DIFF
--- a/server/resources/views/livewire/dispatch-board.blade.php
+++ b/server/resources/views/livewire/dispatch-board.blade.php
@@ -465,6 +465,18 @@
                             $yesterday = now()->subDay()->toDateString();
                             $activeStyle = 'background: var(--d-accent); color: #fff; border-color: var(--d-accent);';
                         @endphp
+                        {{-- View-aware period label, ahead of the picker so it reads naturally. --}}
+                        <div class="d-weekday" style="margin-right:16px; line-height:1.1;">
+                            @if ($this->viewMode === 'month')
+                                <div style="font-size:15px; font-weight:700;">{{ $this->monthLabel }}</div>
+                            @elseif ($this->viewMode === 'list' && $this->listRange === 'week')
+                                <div style="font-size:15px; font-weight:700;">{{ $this->listRangeLabel }}</div>
+                                <div style="font-size:12px; color:var(--d-muted);">Week view</div>
+                            @else
+                                <div style="font-size:15px; font-weight:700;">{{ \Carbon\Carbon::parse($this->date)->format('l') }}</div>
+                                <div style="font-size:12px; color:var(--d-muted);">{{ \Carbon\Carbon::parse($this->date)->format('M j, Y') }}</div>
+                            @endif
+                        </div>
                         <button type="button" wire:click="shiftPeriod(-1)" class="d-icon-btn" title="Previous {{ $unit }}">
                             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
                         </button>
@@ -486,22 +498,9 @@
                             <button type="button" wire:click="$set('date', '{{ $tomorrow }}')" class="d-btn" @if ($this->date === $tomorrow) style="{{ $activeStyle }}" @endif>Tomorrow</button>
                         @endif
 
-                        {{-- View-aware period label — single source of truth for every view. --}}
-                        <div class="d-weekday" style="margin-left:8px; line-height:1.1;">
-                            @if ($this->viewMode === 'month')
-                                <div style="font-size:15px; font-weight:700;">{{ $this->monthLabel }}</div>
-                            @elseif ($this->viewMode === 'list' && $this->listRange === 'week')
-                                <div style="font-size:15px; font-weight:700;">{{ $this->listRangeLabel }}</div>
-                                <div style="font-size:12px; color:var(--d-muted);">Week view</div>
-                            @else
-                                <div style="font-size:15px; font-weight:700;">{{ \Carbon\Carbon::parse($this->date)->format('l') }}</div>
-                                <div style="font-size:12px; color:var(--d-muted);">{{ \Carbon\Carbon::parse($this->date)->format('M j, Y') }}</div>
-                            @endif
-                        </div>
-
-                        {{-- Create a job on the fly (issue #55). Sits right by the date so
-                             it's easy to reach; sized to match the Today button. --}}
-                        <button type="button" wire:click="openNewJobModal" class="d-btn" style="margin-left:2rem;height:32px;background:var(--d-accent);color:#fff;border-color:var(--d-accent);font-weight:600;">
+                        {{-- Create a job on the fly (issue #55). Sits after the date controls
+                             with breathing room; sized to match the Today button. --}}
+                        <button type="button" wire:click="openNewJobModal" class="d-btn" style="margin-left:5rem;height:32px;background:var(--d-accent);color:#fff;border-color:var(--d-accent);font-weight:600;">
                             + New Job
                         </button>
                     </div>

--- a/server/resources/views/livewire/dispatch-board.blade.php
+++ b/server/resources/views/livewire/dispatch-board.blade.php
@@ -194,33 +194,40 @@
             transition: border-color 120ms, box-shadow 120ms;
         }
         .dispatch-page .d-month-cell:hover { border-color: var(--d-accent); box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
-        .dispatch-page .d-month-cell.is-out { opacity: 0.45; }
+        /* Days from the neighbouring month: dim only the day number, not the crew
+           rows, so their text stays fully readable. */
+        .dispatch-page .d-month-cell.is-out { background: color-mix(in srgb, var(--d-border) 18%, var(--d-card-bg)); }
+        .dispatch-page .d-month-cell.is-out .d-month-daynum { color: var(--d-muted); }
         .dispatch-page .d-month-cell.is-today { border-color: var(--d-accent); }
         .dispatch-page .d-month-cell.is-selected { box-shadow: 0 0 0 2px var(--d-accent); }
         .dispatch-page .d-month-daynum-btn {
             font: inherit; border: 0; background: transparent; padding: 0; cursor: pointer;
             align-self: flex-start; color: inherit;
         }
-        .dispatch-page .d-month-daynum { font-size: 13px; font-weight: 600; }
+        .dispatch-page .d-month-daynum { font-size: 13px; font-weight: 700; color: var(--d-text); }
         .dispatch-page .d-month-count {
             font-size: 11px; font-weight: 600; align-self: flex-start;
             background: color-mix(in srgb, var(--d-accent) 15%, transparent); color: var(--d-accent);
             padding: 1px 8px; border-radius: 9999px;
         }
-        /* One crew per row, full-width and clickable → that day's filtered map. */
+        /* One crew per row, full-width and clickable → that day's filtered map.
+           Text is the standard dark colour at full opacity for readability; the
+           crew colour is carried by the dot + border, and the tint mixes with the
+           opaque card background (no see-through fading). */
         .dispatch-page .d-month-crews { display: flex; flex-direction: column; gap: 4px; align-self: stretch; }
         .dispatch-page .d-month-crew {
             font: inherit; cursor: pointer; text-align: left; width: 100%;
             display: flex; align-items: center; gap: 6px;
-            font-size: 11px; font-weight: 600; line-height: 1.2;
-            padding: 4px 8px; border-radius: 6px; border: 1px solid transparent;
-            background: color-mix(in srgb, var(--cc) 12%, transparent); color: var(--cc);
+            font-size: 11px; font-weight: 600; line-height: 1.2; color: var(--d-text);
+            padding: 4px 8px; border-radius: 6px;
+            border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+            background: color-mix(in srgb, var(--cc) 15%, var(--d-card-bg));
             transition: border-color 120ms, background 120ms;
         }
-        .dispatch-page .d-month-crew:hover { border-color: var(--cc); background: color-mix(in srgb, var(--cc) 22%, transparent); }
-        .dispatch-page .d-month-crew-dot { width: 7px; height: 7px; border-radius: 9999px; background: var(--cc); flex-shrink: 0; }
-        .dispatch-page .d-month-crew-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .dispatch-page .d-month-crew-count { flex-shrink: 0; opacity: 0.85; font-weight: 700; }
+        .dispatch-page .d-month-crew:hover { border-color: var(--cc); background: color-mix(in srgb, var(--cc) 28%, var(--d-card-bg)); }
+        .dispatch-page .d-month-crew-dot { width: 8px; height: 8px; border-radius: 9999px; background: var(--cc); flex-shrink: 0; }
+        .dispatch-page .d-month-crew-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--d-text); font-weight: 600; }
+        .dispatch-page .d-month-crew-count { flex-shrink: 0; font-weight: 700; color: var(--d-text); }
         .dispatch-page .d-crew-badge {
             display: inline-block; font-size: 11px; font-weight: 700;
             padding: 2px 10px; border-radius: 9999px; margin-bottom: 10px;
@@ -494,7 +501,7 @@
 
                         {{-- Create a job on the fly (issue #55). Sits right by the date so
                              it's easy to reach; sized to match the Today button. --}}
-                        <button type="button" wire:click="openNewJobModal" class="d-btn" style="margin-left:8px;height:32px;background:var(--d-accent);color:#fff;border-color:var(--d-accent);font-weight:600;">
+                        <button type="button" wire:click="openNewJobModal" class="d-btn" style="margin-left:2rem;height:32px;background:var(--d-accent);color:#fff;border-color:var(--d-accent);font-weight:600;">
                             + New Job
                         </button>
                     </div>


### PR DESCRIPTION
Two small Dispatch fixes.

**Faded Month-view text.** The trailing/leading days of neighbouring months (e.g. Jun 28–29 in the July grid) were dimmed by a cell-wide `opacity: 0.45` that faded the crew rows with them. That opacity is removed — only the out-of-month *day number* is muted now, so crew rows stay fully readable. Crew/day text is also the standard dark colour at full opacity (the crew colour moves to the dot + border), with the row tint over the opaque card background instead of a see-through transparent one.

> Note: the earlier "darker text" commit landed only on the previous feature branch and wasn't part of the merge to `main`, so this re-applies it correctly on top of `main`.

**New Job spacing.** Adds 2rem between the Month/date label and the **+ New Job** button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)